### PR TITLE
Fix overlapping page content

### DIFF
--- a/src/domain/header/_header.scss
+++ b/src/domain/header/_header.scss
@@ -1,3 +1,7 @@
 .app-Header {
   z-index: 4;
+
+  .sticky {
+    z-index: 10;
+  }
 }


### PR DESCRIPTION
 Fix needed because in old versions of Edge main menu goes behind page content when scrolling

Refs TAM-48
