### PR TITLE
Clear cookies sessionid and csrf token when logging out

### DIFF
--- a/server/auth/auth.js
+++ b/server/auth/auth.js
@@ -49,6 +49,8 @@ router.get('/login/tampere/return',
 
 router.get('/logout', (req, res) => {
   req.logOut();
+  res.clearCookie('sso-sessionid');
+  res.clearCookie('sso-csrftoken');
   const redirectUrl = req.query.next || 'https://varaamo.tampere.fi';
   res.redirect(`https://auth.tampere.fi/logout/?next=${redirectUrl}`);
 });


### PR DESCRIPTION
The application is re-using the same sso session and automatically sign-in users if the cookies are not cleared. 

Refs: TAM-73