### PR TITLE
Render equipments either in 2 or single column in resource page

### DIFF
--- a/app/pages/resource/resource-equipment/ResourceEquipment.js
+++ b/app/pages/resource/resource-equipment/ResourceEquipment.js
@@ -11,7 +11,7 @@ function ResourceEquipment({
   t,
 }) {
   const equipmentColumns = equipment.map(
-    (item, i) => <Col key={i} lg={3} md={3} xs={6}>{item.name}</Col>,
+    (item, i) => <Col key={i} lg={6} md={6} xs={12}>{item.name}</Col>,
   );
   return (
     <ResourcePanel header={t('ResourceEquipment.headingText')}>

--- a/app/pages/resource/resource-equipment/__tests__/__snapshots__/ResourceEquipment.test.js.snap
+++ b/app/pages/resource/resource-equipment/__tests__/__snapshots__/ResourceEquipment.test.js.snap
@@ -12,9 +12,9 @@ exports[`pages/resource/resource-equipment/ResourceEquipment 1`] = `
       bsClass="col"
       componentClass="div"
       key="0"
-      lg={3}
-      md={3}
-      xs={6}
+      lg={6}
+      md={6}
+      xs={12}
     >
       Karaoke
     </Col>
@@ -22,9 +22,9 @@ exports[`pages/resource/resource-equipment/ResourceEquipment 1`] = `
       bsClass="col"
       componentClass="div"
       key="1"
-      lg={3}
-      md={3}
-      xs={6}
+      lg={6}
+      md={6}
+      xs={12}
     >
       Projector
     </Col>
@@ -32,9 +32,9 @@ exports[`pages/resource/resource-equipment/ResourceEquipment 1`] = `
       bsClass="col"
       componentClass="div"
       key="2"
-      lg={3}
-      md={3}
-      xs={6}
+      lg={6}
+      md={6}
+      xs={12}
     >
       Printer
     </Col>


### PR DESCRIPTION
Render the equipments in 2 columns for large and medium devices,
and only in single column for extra small devices.

![equipment_rendering_varaamo](https://user-images.githubusercontent.com/19978017/158793363-2bacbe30-0f8b-4b7a-848f-05ce518b3867.png)
