### PR TITLE
Disable language selection

### DIFF
--- a/app/i18n/TranslationConstants.js
+++ b/app/i18n/TranslationConstants.js
@@ -1,5 +1,6 @@
 export const SUPPORTED_LANGUAGES = {
   FI: 'fi',
-  SV: 'sv',
-  EN: 'en',
+  // TODO: TAM-117: Enable other language when the translation files are up to date.
+  // SV: 'sv',
+  // EN: 'en',
 };


### PR DESCRIPTION
The english and swedish translations are not upto date. Therefore,
disable the language selection dropdown for now. This means that
the current active language will be Finnish.

Undo the changes when the translation files are fixed.

Removed the language dropdown for now.

![Screenshot 2022-04-04 at 10 48 29](https://user-images.githubusercontent.com/19978017/161498027-96a95e27-18f6-4ed0-b365-20316306e677.png)
