### PR TITLE
Allow the backend to have empty max_period for resource (TAM-107)

### DIFF
--- a/src/domain/resource/resourceKeyboardReservation/ResourceKeyboardSlotPicker.js
+++ b/src/domain/resource/resourceKeyboardReservation/ResourceKeyboardSlotPicker.js
@@ -4,7 +4,7 @@ import moment from 'moment';
 
 import Constants from '../../../../app/constants/AppConstants';
 import injectT from '../../../../app/i18n/injectT';
-import { getIsSlotReserved, getIsSlotInPast, getInMs } from './resourceKeyboardSlotPickerUtils';
+import { getIsSlotReserved, getIsSlotInPast, getSlotCount } from './resourceKeyboardSlotPickerUtils';
 
 const rootClass = 'app-ResourcePageKeyboardTimePicker';
 
@@ -21,15 +21,6 @@ function getTime(dateTime) {
   const dateTimeInAppTimeZone = moment(dateTime).tz(Constants.TIME_ZONE);
 
   return dateTimeInAppTimeZone.format('HH:mm');
-}
-
-function getSlotCount(time, slotSize) {
-  const [timeHours, timeMinutes] = time.split(':');
-  const timeInMs = getInMs(timeHours, timeMinutes);
-  const [slotHours, slotMinutes] = slotSize.split(':');
-  const slotSizeInMs = getInMs(slotHours, slotMinutes);
-
-  return timeInMs / slotSizeInMs;
 }
 
 function labelStartTimeOptions(

--- a/src/domain/resource/resourceKeyboardReservation/__tests__/resourceKeyboardSlotPickerUtils.test.js
+++ b/src/domain/resource/resourceKeyboardReservation/__tests__/resourceKeyboardSlotPickerUtils.test.js
@@ -1,4 +1,4 @@
-import { getSlots } from '../resourceKeyboardSlotPickerUtils';
+import { getSlots, getSlotCount } from '../resourceKeyboardSlotPickerUtils';
 
 describe('resourcePageKeyboardTimPickerUtils', () => {
   describe('getSlots', () => {
@@ -17,6 +17,13 @@ describe('resourcePageKeyboardTimPickerUtils', () => {
           end: new Date(2017, 6, 7, 11, 59, 59, 999).toJSON(),
         },
       ]);
+    });
+  });
+
+  describe('slotSize', () => {
+    test('should return max slot size if end time is empty', () => {
+      const slotCount = getSlotCount(null, '1:00:00');
+      expect(slotCount).toBe(23.5);
     });
   });
 });

--- a/src/domain/resource/resourceKeyboardReservation/resourceKeyboardSlotPickerUtils.js
+++ b/src/domain/resource/resourceKeyboardReservation/resourceKeyboardSlotPickerUtils.js
@@ -117,3 +117,19 @@ export function getNextFreeSlot(slots, reservations) {
     end: null,
   };
 }
+
+
+export function getSlotCount(time, slotSize) {
+  let duration = time;
+  // If the resource doesn't have max reservable period (max_period), manually assign
+  // it the max possible value so we get max slots available
+  if (!duration) {
+    duration = '23:30:00';
+  }
+  const [timeHours, timeMinutes] = duration.split(':');
+  const timeInMs = getInMs(timeHours, timeMinutes);
+  const [slotHours, slotMinutes] = slotSize.split(':');
+  const slotSizeInMs = getInMs(slotHours, slotMinutes);
+
+  return timeInMs / slotSizeInMs;
+}


### PR DESCRIPTION
A new empty choice field is added to backend for max reservable
period for resource. If this field (max_period) is empty in
backend, then user should be able to choose as many available
slots as they can.
