### PR TITLE
Render the notification message for longer duration (6 sec) (TAM-120)

### DIFF
--- a/src/common/notification/utils.js
+++ b/src/common/notification/utils.js
@@ -12,7 +12,7 @@ import { NOTIFICATION_TYPE } from './constants';
  * @param {function} callback
  * @returns {void}
  */
-export const createNotification = (type, message = '', title = '', fadeTime = 2000, callback) => {
+export const createNotification = (type, message = '', title = '', fadeTime = 6000, callback) => {
   switch (type) {
     case NOTIFICATION_TYPE.INFO:
       NotificationManager.info(message, title, fadeTime, callback);


### PR DESCRIPTION
When the notification message pop up, the duration is a bit shor-
ter for users to read all the contents of message. Also, client
will add longer text on the notification in the future. Therefore,
extend the duration to 6 seconds for notification pop up.

Refs TAM-120