### PR TITLE
Bounce the calendar selection to nearest valid available slot (TAM-119)

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -471,7 +471,7 @@
   "ResourceReservationCalendar.selectedDateLabel": "Selected time:",
   "ResourceReservationCalendar.selectedDateValue": "{date} at {start} - at {end} ({duration})",
   "ResourceReservationCalendar.selectedDateValueWithPrice": "{date} at {start} - at {end} ({duration}) for {price}€",
-
+  "TimePickerCalendar.info.calendarSelectionMovedText": "Your selection is not available. Selection moved to nearest available slot.",
   "TimePickerCalendar.info.minPeriodText": "Reservation must be at least {duration}h long",
   "TimePickerCalendar.info.maxPeriodText": "Reservation must be shorter than {duration}h",
   "TimePickerCalendar.info.today": "Today",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -480,7 +480,7 @@
   "ResourceReservationCalendar.selectedDateLabel": "Valittu aika:",
   "ResourceReservationCalendar.selectedDateValue": "{date} klo {start} - klo {end} ({duration})",
   "ResourceReservationCalendar.selectedDateValueWithPrice": "{date} klo {start} - klo {end} ({duration}) yht {price}€",
-
+  "TimePickerCalendar.info.calendarSelectionMovedText": "Ajankohdan valinta on sovitettu kalenteriasetuksia vastaavaksi",
   "TimePickerCalendar.info.minPeriodText": "Varauksen on kestettävä vähintään {duration} tuntia.",
   "TimePickerCalendar.info.maxPeriodText": "Varaus saa kestää enimmillään {duration} tuntia.",
   "TimePickerCalendar.info.today": "Tänään",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -473,7 +473,7 @@
   "ResourceReservationCalendar.selectedDateLabel": "Utvald tidpunkt:",
   "ResourceReservationCalendar.selectedDateValue": "{date} kl. {start} - kl. {end} ({duration})",
   "ResourceReservationCalendar.selectedDateValueWithPrice": "{date} kl. {start} - kl. {end} ({duration}) for {price}€",
-
+  "TimePickerCalendar.info.calendarSelectionMovedText": "__swedish__",
   "TimePickerCalendar.info.minPeriodText": "Bokningen måste vara minst {duration} timmar lång.",
   "TimePickerCalendar.info.maxPeriodText": "Bokningen får vara högst {duration} timmar lång.",
   "TimePickerCalendar.info.today": "Idag",

--- a/src/common/calendar/TimePickerCalendar.js
+++ b/src/common/calendar/TimePickerCalendar.js
@@ -9,6 +9,7 @@ import svLocale from '@fullcalendar/core/locales/sv';
 import fiLocale from '@fullcalendar/core/locales/fi';
 import moment from 'moment';
 import get from 'lodash/get';
+import { orderBy, find } from 'lodash';
 import classNames from 'classnames';
 import isEmpty from 'lodash/isEmpty';
 
@@ -19,6 +20,9 @@ import injectT from '../../../app/i18n/injectT';
 import * as calendarUtils from './utils';
 import { createNotification } from '../notification/utils';
 import { NOTIFICATION_TYPE } from '../notification/constants';
+import { getOpeningHours } from '../../../app/utils/resourceUtils';
+import { getSlots } from '../../domain/resource/resourceKeyboardReservation/resourceKeyboardSlotPickerUtils';
+import { toCamelCase } from '../data/utils';
 
 const NEW_RESERVATION = 'NEW_RESERVATION';
 
@@ -186,8 +190,22 @@ class TimePickerCalendar extends Component {
         );
       }
 
-      selectable = calendarUtils.getMinPeriodTimeRange(resource, selected.start, selected.end);
       // Make sure selected time will always bigger than min period
+      selectable = calendarUtils.getMinPeriodTimeRange(resource, selected.start, selected.end);
+
+      // Move the selection to nearest available slot
+      if (!this.isSelectionValid(selectable)) {
+        const nearestSlot = this.getNearestValidSlot(selectable, resource);
+        selectable = nearestSlot[0];
+        const nearestSlotIsValid = nearestSlot[1];
+
+        if (nearestSlotIsValid) {
+          createNotification(
+            NOTIFICATION_TYPE.INFO,
+            t('TimePickerCalendar.info.calendarSelectionMovedText'),
+          );
+        }
+      }
     }
 
     if (isOverMaxPeriod) {
@@ -209,6 +227,43 @@ class TimePickerCalendar extends Component {
     }
 
     return selectable;
+  }
+
+  getSlotsForDate = (date, resource) => {
+    const { opens, closes } = getOpeningHours(toCamelCase(resource), date);
+    const slots = getSlots(opens, closes, resource.slot_size);
+    const sortedSlots = orderBy(slots, 'start', 'desc');
+    return sortedSlots;
+  }
+
+  getNearestValidSlot = (selected) => {
+    const { resource } = this.props;
+    const startMoment = moment(selected.start).toJSON();
+    const selectedDate = startMoment.split('T')[0];
+    const slots = this.getSlotsForDate(selectedDate, resource);
+    const indexOfSelectedSlot = slots.indexOf(find(slots, { start: startMoment }));
+    const lowerSlotsFromSelectedStart = slots.slice(0, indexOfSelectedSlot + 1);
+    const upperSlotsFromSelectedStart = slots.slice(indexOfSelectedSlot + 1);
+    const arrangedSlots = [
+      ...upperSlotsFromSelectedStart,
+      ...(orderBy(lowerSlotsFromSelectedStart, 'start', 'asc')),
+    ];
+    const minPeriod = get(resource, 'min_period', null);
+    const minPeriodDuration = moment.duration(minPeriod).asMinutes();
+    let selectable = { start: '', end: '' };
+
+    for (let x = 0; x < arrangedSlots.length; x++) {
+      const adjustedStart = moment(arrangedSlots[x].start);
+      selectable = {
+        start: adjustedStart.toDate(),
+        end: adjustedStart.add(minPeriodDuration, 'minutes').toDate(),
+      };
+
+      if (this.isSelectionValid(selectable)) {
+        return [selectable, true];
+      }
+    }
+    return [selected, false];
   }
 
   getDurationText = (selected) => {

--- a/src/common/calendar/__tests__/TimePickerCalendar.test.js
+++ b/src/common/calendar/__tests__/TimePickerCalendar.test.js
@@ -1,10 +1,49 @@
 import React from 'react';
 import toJson from 'enzyme-to-json';
+import moment from 'moment';
 
 import TimePickerCalendar from '../TimePickerCalendar';
 import resource from '../../data/fixtures/resource';
 import reservation from '../../data/fixtures/reservation';
 import { globalDateMock, shallowWithIntl } from '../../../../app/utils/testUtils';
+
+describe('Calendar reservation selection', () => {
+  // Change the date so that test runs with this 'now'.
+  Date.now = jest.fn(() => new Date('2019-12-17T11:00:00+03:00'));
+  const defaultProps = {
+    resource: resource.build(),
+    date: '2019-08-15',
+    isStaff: false,
+    onDateChange: jest.fn(),
+    onReserve: jest.fn(),
+    onTimeChange: jest.fn(),
+  };
+  const selectedInvalidSlot = {
+    start: moment('2019-12-17T17:00:00.000Z').toDate(),
+    end: moment('2019-12-17T18:00:00.000Z').toDate(),
+  };
+  const resourceOpeningHours = [{
+    date: '2019-12-17',
+    opens: '2019-12-17T09:00:00.000Z',
+    closes: '2019-12-17T18:00:00.000Z',
+  }];
+  const userResource = resource.build({
+    opening_hours: resourceOpeningHours,
+    min_period: '01:30:00',
+  });
+  const getWrapper = props => shallowWithIntl(<TimePickerCalendar {...defaultProps} {...props} />);
+  const wrapper = getWrapper({ resource: userResource, date: '2019-12-17' });
+
+  test('bounces to valid avalilable slot if selection is not valid', () => {
+    // The valid slot is from 16:30 - 18:00 if user's selected slot starts from 17:00
+    const instance = wrapper.instance();
+    const bouncedSlot = instance.getSelectableTimeRange(selectedInvalidSlot);
+
+    expect(bouncedSlot.start.toJSON()).toBe('2019-12-17T16:30:00.000Z');
+    expect(bouncedSlot.end.toJSON()).toBe('2019-12-17T18:00:00.000Z');
+  });
+});
+
 
 describe('TimePickerCalendar', () => {
   globalDateMock();


### PR DESCRIPTION
Bounce the user's calendar selection to nearest valid slot if the
slot/selection of the user is not valid.

E.g. If the slot size is 1 hour and minimum reservation time is 2 hours
and user clicks on the last hour of calendar (say 17:00 i.e. The last
valid reservation is from 15:00 - 17:00).  Since the user clicked on 17:00,
the reservation 17:00 - 19:00 is not valid as it closes at 17:00, Thus, 
change the user's selection to start at 15:00 and notify the user of the
change.

![bounce_to_nearest_hours](https://user-images.githubusercontent.com/19978017/168064065-36276b4c-c46e-4ecd-a3ee-a70560d88f1d.gif)


Refs TAM-119