### PR TITLE
Do not exclude mininum starting price for resource if it is zero (TAM-129)

### DIFF
--- a/src/domain/resource/utils.js
+++ b/src/domain/resource/utils.js
@@ -92,7 +92,7 @@ export const getPrice = (minPriceString, maxPriceString, priceType, t) => {
     week: t('common.unit.time.week'),
   });
 
-  if (minPrice && maxPrice && minPrice !== maxPrice) {
+  if (minPrice >= 0 && maxPrice && minPrice !== maxPrice) {
     return `${Number(minPrice)} - ${Number(maxPrice)} ${priceEnding}`;
   }
 


### PR DESCRIPTION
When the price for the resource is rendered, currently it excludes
the min price if it is zero. Do not exclude the min price even if
it is zero. If it is zero render it as 0 - max_price in resource info
and resource card.
