### PR TITLE
Entire opening hour reservation

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -375,6 +375,7 @@
   "ResourceInfo.loginMessage": "You must <a href=”/login”>log in</a> to reserve these premises.",
   "ResourceInfo.reservationTitle": "Reservation details",
   "ResourceInfo.reserveTitle": "Reserve",
+  "ReservationInfo.wholeDayReservation": "Whole day reservation __english__",
   "ResourceInfoContainer.unpublishedLabel": "unpublished",
   "ResourceKeyboardReservation.dateLabel": "Date",
   "ResourceKeyboardSlotPicker.startTimeLabel": "Reservation starting time",
@@ -474,6 +475,7 @@
   "TimePickerCalendar.info.calendarSelectionMovedText": "Your selection is not available. Selection moved to nearest available slot.",
   "TimePickerCalendar.info.minPeriodText": "Reservation must be at least {duration}h long",
   "TimePickerCalendar.info.maxPeriodText": "Reservation must be shorter than {duration}h",
+  "TimePickerCalendar.info.shouldBeReservedWholeDayText": "Resource should be reserved whole day.",
   "TimePickerCalendar.info.today": "Today",
   "TimePickerCalendar.info.displayedMessage": "The resource cannot be reserved at this time",
 

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -375,6 +375,7 @@
   "ResourceInfo.loginMessage": "Sinun täytyy <a href=\"/login\">kirjautua sisään</a>, jotta voit tehdä varauksen tähän tilaan.",
   "ResourceInfo.reservationTitle": "Varauksen tiedot",
   "ResourceInfo.reserveTitle": "Varaa",
+  "ReservationInfo.wholeDayReservation": "Varauksen pituus: koko päivä",
   "ResourceInfoContainer.unpublishedLabel": "ei julkaistu",
   "ResourceKeyboardReservation.dateLabel": "Päivämäärä",
   "ResourceKeyboardSlotPicker.startTimeLabel": "Varauksen aloitusaika",
@@ -483,6 +484,7 @@
   "TimePickerCalendar.info.calendarSelectionMovedText": "Ajankohdan valinta on sovitettu kalenteriasetuksia vastaavaksi",
   "TimePickerCalendar.info.minPeriodText": "Varauksen on kestettävä vähintään {duration} tuntia.",
   "TimePickerCalendar.info.maxPeriodText": "Varaus saa kestää enimmillään {duration} tuntia.",
+  "TimePickerCalendar.info.shouldBeReservedWholeDayText": "Tähän tilaan voi tehdä ainoastaan koko päivän varauksia.",
   "TimePickerCalendar.info.today": "Tänään",
   "TimePickerCalendar.info.displayedMessage": "Kohde ei ole varattavissa",
 

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -381,6 +381,7 @@
   "ResourceKeyboardSlotPicker.endTimeLabel": "Bokningens sluttid",
   "ResourceInfo.reservationTitle": "Bokningsinformation",
   "ResourceInfo.reserveTitle": "Boka",
+  "ReservationInfo.wholeDayReservation": "Whole day reservation __swedish__",
   "ResourceInfoContainer.unpublishedLabel": "opublicerad",
   "ResourcePage.back": "Tillbaka till sökresultat",
   "ResourcePage.reservationStatusHeader": "Bokningsläget",
@@ -476,6 +477,7 @@
   "TimePickerCalendar.info.calendarSelectionMovedText": "__swedish__",
   "TimePickerCalendar.info.minPeriodText": "Bokningen måste vara minst {duration} timmar lång.",
   "TimePickerCalendar.info.maxPeriodText": "Bokningen får vara högst {duration} timmar lång.",
+  "TimePickerCalendar.info.shouldBeReservedWholeDayText": "Resource should be reserved whole day __swedish__",
   "TimePickerCalendar.info.today": "Idag",
   "TimePickerCalendar.info.displayedMessage": "För tillfället kan resursen inte bokas",
 

--- a/app/pages/resource/reservation-info/ReservationInfo.js
+++ b/app/pages/resource/reservation-info/ReservationInfo.js
@@ -57,7 +57,7 @@ const renderLastResDay = (resource, t) => {
   );
 };
 
-function renderMaxPeriodText(resource, t) {
+function getMaximumPeriodText(resource, t) {
   if (!resource.maxPeriod) {
     return null;
   }
@@ -71,7 +71,7 @@ function renderMaxPeriodText(resource, t) {
   );
 }
 
-function renderMinPeriodText(resource, t) {
+function getMinimumPeriodText(resource, t) {
   if (!resource.minPeriod) {
     return null;
   }
@@ -98,14 +98,32 @@ function renderMaxReservationsPerUserText(maxReservationsPerUser, t) {
   );
 }
 
+function renderReservationPeriodInfo(resource, t) {
+  if (resource.shouldBeReservedWholeDay) {
+    return (
+      <p className="app-ResourcePage__content-whole-day-reservation">
+        <img alt="" className="app-ResourceHeader__info-icon" src={iconClock} />
+        <strong>{t('ReservationInfo.wholeDayReservation')}</strong>
+      </p>
+    );
+  }
+  const minPeriodText = getMinimumPeriodText(resource, t);
+  const maxPeriodText = getMaximumPeriodText(resource, t);
+  return (
+    <>
+      {minPeriodText}
+      {maxPeriodText}
+    </>
+  );
+}
+
 function ReservationInfo({ isLoggedIn, resource, t }) {
   return (
     <div className="app-ReservationInfo">
       <WrappedText openLinksInNewTab text={resource.reservationInfo} />
       {renderEarliestResDay(resource, t)}
       {renderLastResDay(resource, t)}
-      {renderMinPeriodText(resource, t)}
-      {renderMaxPeriodText(resource, t)}
+      {renderReservationPeriodInfo(resource, t)}
       {renderMaxReservationsPerUserText(resource.maxReservationsPerUser, t)}
       {renderLoginText(isLoggedIn, resource)}
     </div>

--- a/app/pages/resource/reservation-info/__tests__/ReservationInfo.test.js
+++ b/app/pages/resource/reservation-info/__tests__/ReservationInfo.test.js
@@ -118,4 +118,34 @@ describe('pages/resource/reservation-info/ReservationInfo', () => {
       expect(loginText).toHaveLength(1);
     });
   });
+
+  describe('reservation period text', () => {
+    test(
+      'has minimum and maximum hours rendered if not reservable for whole day',
+      () => {
+        const resource = { maxPeriod: '04:00:00', minPeriod: '03:00:00' };
+        const wrapper = getWrapper({ resource });
+        const minReservationPeriodParagraph = wrapper.find('.app-ResourcePage__content-min-period');
+        const maxReservationPeriodParagraph = wrapper.find('.max-length-text');
+        const wholeDayReservationParagraph = wrapper.find('.app-ResourcePage__content-whole-day-reservation');
+
+        expect(minReservationPeriodParagraph).toHaveLength(1);
+        expect(maxReservationPeriodParagraph).toHaveLength(1);
+        expect(wholeDayReservationParagraph).toHaveLength(0);
+      },
+    );
+
+    test(
+      'reservation for whole day info rendered if reservable for whole day',
+      () => {
+        const resource = { minPeriod: '03:00:00', shouldBeReservedWholeDay: true };
+        const wrapper = getWrapper({ resource });
+        const maxReservationPeriodParagraph = wrapper.find('.max-length-text');
+        const wholeDayReservationParagraph = wrapper.find('.app-ResourcePage__content-whole-day-reservation');
+
+        expect(wholeDayReservationParagraph).toHaveLength(1);
+        expect(maxReservationPeriodParagraph).toHaveLength(0);
+      },
+    );
+  });
 });

--- a/app/utils/fixtures/Resource.js
+++ b/app/utils/fixtures/Resource.js
@@ -19,5 +19,6 @@ const Resource = new Factory()
   .attr('isFavorite', false)
   .attr('slotSize', DEFAULT_SLOT_SIZE)
   .attr('products', [])
+  .attr('shouldBeReservedWholeDay', false)
   .attr('area', 13);
 export default Resource;

--- a/src/common/calendar/TimePickerCalendar.js
+++ b/src/common/calendar/TimePickerCalendar.js
@@ -171,6 +171,25 @@ class TimePickerCalendar extends Component {
       end: selected.end,
     };
 
+    // If the resource can be reserved for whole day then, then fill all
+    // available hours for that day.
+    if (resource.should_be_reserved_whole_day) {
+      if (eventCallback) {
+        eventCallback.revert();
+        createNotification(
+          NOTIFICATION_TYPE.INFO, t('TimePickerCalendar.info.shouldBeReservedWholeDayText'),
+        );
+      }
+      const startMoment = moment(selected.start).toJSON();
+      const selectedDate = startMoment.split('T')[0];
+      const slots = this.getSlotsForDate(selectedDate, resource);
+      selectable = {
+        start: moment(slots[slots.length - 1].start).toDate(),
+        // Add 1 millisecond to round the hour/minute
+        end: moment(slots[0].end).add('1', 'millisecond').toDate(),
+      };
+    }
+
     const isUnderMinPeriod = calendarUtils.isTimeRangeUnderMinPeriod(
       resource, selectable.start, selectable.end,
     );

--- a/src/common/calendar/__tests__/TimePickerCalendar.test.js
+++ b/src/common/calendar/__tests__/TimePickerCalendar.test.js
@@ -42,6 +42,25 @@ describe('Calendar reservation selection', () => {
     expect(bouncedSlot.start.toJSON()).toBe('2019-12-17T16:30:00.000Z');
     expect(bouncedSlot.end.toJSON()).toBe('2019-12-17T18:00:00.000Z');
   });
+
+  test('fills entire opening hours if resource should be reserved for whole day', () => {
+    const wholeDayResourceOpeningHours = [{
+      date: '2019-12-17',
+      opens: '2019-12-17T09:00:00.000Z',
+      closes: '2019-12-17T17:00:00.000Z',
+    }];
+    const wholeDayResource = resource.build({
+      should_be_reserved_whole_day: true,
+      min_period: '04:30:00',
+      opening_hours: wholeDayResourceOpeningHours,
+    });
+    const wholeDayResourceWrapper = getWrapper({ resource: wholeDayResource, date: '2019-12-17' });
+    const instance = wholeDayResourceWrapper.instance();
+    const wholeDayReservationHours = instance.getSelectableTimeRange(selectedInvalidSlot);
+
+    expect(wholeDayReservationHours.start.toJSON()).toBe(wholeDayResourceOpeningHours[0].opens);
+    expect(wholeDayReservationHours.end.toJSON()).toBe(wholeDayResourceOpeningHours[0].closes);
+  });
 });
 
 

--- a/src/common/data/fixtures/resource.js
+++ b/src/common/data/fixtures/resource.js
@@ -19,4 +19,5 @@ export default new Factory()
   .attr('user_permissions', { isAdmin: false, canMakeReservations: true })
   .attr('is_favorite', false)
   .attr('slot_size', DEFAULT_SLOT_SIZE)
+  .attr('should_be_reserved_whole_day', false)
   .attr('products', []);

--- a/src/domain/resource/card/__tests__/__snapshots__/ResourceCard.test.js.snap
+++ b/src/domain/resource/card/__tests__/__snapshots__/ResourceCard.test.js.snap
@@ -70,6 +70,7 @@ exports[`ResourceCard renders correctly 1`] = `
                 "required_reservation_extra_fields": Array [],
                 "reservable": true,
                 "reservable_after": null,
+                "should_be_reserved_whole_day": false,
                 "slot_size": "00:30:00",
                 "supported_reservation_extra_fields": Array [],
                 "unit": 1,

--- a/src/domain/resource/card/slider/__tests__/__snapshots__/ResourceCardSlider.test.js.snap
+++ b/src/domain/resource/card/slider/__tests__/__snapshots__/ResourceCardSlider.test.js.snap
@@ -29,6 +29,7 @@ exports[`ResourceCardSlider renders correctly 1`] = `
         "required_reservation_extra_fields": Array [],
         "reservable": true,
         "reservable_after": null,
+        "should_be_reserved_whole_day": false,
         "slot_size": "00:30:00",
         "supported_reservation_extra_fields": Array [],
         "unit": 1,

--- a/src/domain/resource/map/__tests__/__snapshots__/ResourceMap.test.js.snap
+++ b/src/domain/resource/map/__tests__/__snapshots__/ResourceMap.test.js.snap
@@ -52,6 +52,7 @@ exports[`ResourceMap renders correctly 1`] = `
             "required_reservation_extra_fields": Array [],
             "reservable": true,
             "reservable_after": null,
+            "should_be_reserved_whole_day": false,
             "slot_size": "00:30:00",
             "supported_reservation_extra_fields": Array [],
             "unit": 1,

--- a/src/domain/resource/reservationCalendar/__tests__/__snapshots__/ResourceReservationCalendar.test.js.snap
+++ b/src/domain/resource/reservationCalendar/__tests__/__snapshots__/ResourceReservationCalendar.test.js.snap
@@ -26,6 +26,7 @@ exports[`ResourceReservationCalendar renders correctly 1`] = `
         "required_reservation_extra_fields": Array [],
         "reservable": true,
         "reservable_after": null,
+        "should_be_reserved_whole_day": false,
         "slot_size": "00:30:00",
         "supported_reservation_extra_fields": Array [],
         "unit": 1,

--- a/src/domain/search/results/__tests__/__snapshots__/SearchListResults.test.js.snap
+++ b/src/domain/search/results/__tests__/__snapshots__/SearchListResults.test.js.snap
@@ -57,6 +57,7 @@ exports[`SearchListResults renders correctly 1`] = `
             "required_reservation_extra_fields": Array [],
             "reservable": true,
             "reservable_after": null,
+            "should_be_reserved_whole_day": false,
             "slot_size": "00:30:00",
             "supported_reservation_extra_fields": Array [],
             "unit": 1,

--- a/src/domain/search/results/__tests__/__snapshots__/SearchMapResults.test.js.snap
+++ b/src/domain/search/results/__tests__/__snapshots__/SearchMapResults.test.js.snap
@@ -66,6 +66,7 @@ exports[`SearchMapResults renders correctly 1`] = `
               "required_reservation_extra_fields": Array [],
               "reservable": true,
               "reservable_after": null,
+              "should_be_reserved_whole_day": false,
               "slot_size": "00:30:00",
               "supported_reservation_extra_fields": Array [],
               "unit": 1,


### PR DESCRIPTION
Allow users to reserve the resource for an entire opening hours when they click on the calendar view
to reserve the resource. The amount of opening hours can differ between the days. i.e. On Monday
a resource can open for 4 hours while on Tuesday it can open for 7 hours. When clicked to reserve
on Monday, it should reserve for entire 4 hours, on Tuesday it should reserve for 7 hours.

NOTE: Merge ![TAM-119](https://github.com/andersinno/varaamo/pull/46) before this.

![entire_day_reservation](https://user-images.githubusercontent.com/19978017/170942673-368e64cd-33da-46c4-a364-e48d411702f3.gif)
