### PR TITLE
About us page text changes (TAM-134)

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -150,7 +150,7 @@
   "Footer.espooText": "Varaamo is the City of Helsinki’s reservation booking system, which is being trialled in certain premises provided by Espoo City Library. This is a pilot version, so please feel free to send us any feedback you may have.",
   "Footer.feedbackLink": "You can send your feedback here.",
   "Footer.helsinkiText": "Varaamo is the City of Helsinki’s reservation booking system. This is a pilot version, so please feel free to send us any feedback you may have.",
-  "Footer.tampereText": "Varaamo is the City of Tampere’s reservation booking system. This is a pilot version, so please feel free to send us any feedback you may have.",
+  "Footer.tampereText": "Varaamo is the City of Tampere’s reservation booking system.",
   "Footer.vantaaText": "Varaamo is the City of Helsinki’s reservation booking system, which is also used by the cities of Espoo and Vantaa. This is a pilot version, so please feel free to send us any feedback you may have.",
   "HeaderContrastControl.label": "Contrast",
   "HeaderFontSizeControl.label": "Text size",

--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -1,9 +1,7 @@
 {
   "AboutPage.title": "Information about the service",
   "AboutPageContent.basedOnParagraph": "Varaamo is based on the City of Helsinki’s public <a href=\"http://dev.hel.fi/apis/respa\"> reservation booking system</a>, which has been implemented as a part of the <a href=\"http://6aika.fi\">6aika - Open and Smart Services</a> project of the six largest cities in Finland.",
-  "AboutPageContent.customerRegisterHeader": "Client register description",
   "AboutPageContent.customerRegisterLink": "Client register description",
-  "AboutPageContent.customerRegisterParagraph": "You can find the client register description associated with the service here: ",
   "AboutPageContent.defaultHeader": "Information about the varaamo.hel.fi service",
   "AboutPageContent.defaultLead": "Varaamo is an online service maintained by the City of Helsinki, which enables you to book the City’s public premises and workstations for private use.",
   "AboutPageContent.defaultReservableParagraph": "During the pilot stage you can use the service to reserve the premises, workstations and equipment of the City Library, Youth Department, and the Department of Early Education and Care.",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -1,9 +1,7 @@
 {
   "AboutPage.title": "Tietoa palvelusta",
   "AboutPageContent.basedOnParagraph": "Varaamo perustuu Helsingin kaupungin avoimeen <a href=\"http://dev.hel.fi/apis/respa\"> tilavarausrajapintaan</a>, joka on toteutettu osana Suomen suurimpien kaupunkien yhteistä <a href=\"http://6aika.fi\">6aika - Avoimet ja älykkäät palvelut</a> -hanketta.",
-  "AboutPageContent.customerRegisterHeader": "Asiakasrekisteriseloste",
-  "AboutPageContent.customerRegisterLink": "Asiakasrekisteriseloste",
-  "AboutPageContent.customerRegisterParagraph": "Palveluun liittyvän asiakasrekisteriselosteen näet täältä: ",
+  "AboutPageContent.customerRegisterLink": "Tietosuojaseloste",
   "AboutPageContent.defaultHeader": "Tietoa varaamo.hel.fi –palvelusta",
   "AboutPageContent.defaultLead": "Varaamo on Helsingin kaupungin ylläpitämä verkkopalvelu, jonka kautta voi varata kaupungin julkisia tiloja sekä työpisteitä yksityiseen käyttöön.",
   "AboutPageContent.defaultReservableParagraph": "Pilottivaiheessa palvelun kautta on varattavissa kaupunginkirjaston, nuorisoasiainkeskuksen sekä varhaiskasvatusviraston tiloja, työpisteitä ja laitteita.",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -150,7 +150,7 @@
   "Footer.espooText": "Varaamo on Helsingin kaupungin tilanvarauspalvelu, jota kokeillaan Espoon kaupunginkirjaston tiloissa. Kyseessä on pilottiversio, josta toivomme Sinulta palautetta.",
   "Footer.feedbackLink": "Palautteesi voit lähettää täältä.",
   "Footer.helsinkiText": "Varaamo on Helsingin kaupungin tilanvarauspalvelu. Kyseessä on pilottiversio, josta toivomme Sinulta palautetta.",
-  "Footer.tampereText": "Varaamo on Tampereen kaupunkiseudun tilanvarauspalvelu. Kyseessä on pilottiversio, josta toivomme Sinulta palautetta.",
+  "Footer.tampereText": "Varaamo on Tampereen kaupunkiseudun tilanvarauspalvelu.",
   "Footer.vantaaText": "Varaamo on Helsingin kaupungin tilanvarauspalvelu, jota kokeillaan Vantaalla alkuvaiheessa Tikkurilan kirjaston ja Pointin tiloissa. Kyseessä on pilottiversio, josta toivomme Sinulta palautetta.",
   "HeaderContrastControl.label": "Kontrasti",
   "HeaderFontSizeControl.label": "Tekstikoko",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -152,7 +152,7 @@
   "Footer.espooText": "Varaamo är Helsingfors stads utrymmesbokningstjänst, som kommer att provas i vissa av Esbo stadsbiblioteks utrymmen. Det är frågan om en pilotversion och vi hoppas att Du ger oss respons på den.",
   "Footer.feedbackLink": "Du kan ge din respons här.",
   "Footer.helsinkiText": "Varaamo är Helsingfors stads utrymmesbokningstjänst. Det är frågan om en pilotversion och vi hoppas att Du  ger oss respons på den.",
-  "Footer.tampereText": "Varaamo är Tammerfors stads utrymmesbokningstjänst. Det är frågan om en pilotversion och vi hoppas att Du ger oss respons på den.",
+  "Footer.tampereText": "Varaamo är Tammerfors stads utrymmesbokningstjänst.",
   "Footer.vantaaText": "Varaamo är Helsingfors stads utrymmesbokningstjänst, som kommer att provas under ett års tid i vissa av Vanda biblioteks utrymmen. Det är frågan om en pilotversion och vi hoppas att Du ger oss respons på den.",
   "HeaderContrastControl.label": "Kontrast",
   "HeaderFontSizeControl.label": "Textstorlek",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -1,9 +1,7 @@
 {
   "AboutPage.title": "Information om tjänsten",
   "AboutPageContent.basedOnParagraph": "Varaamo baserar sig på Helsingfors stads öppna <a href=\"http://dev.hel.fi/apis/respa”> gränssnitt för utrymmesbokning</a>, som genomförts genom projektet <a href=”http://6aika.fi”>6aika - Avoimet ja älykkäät palvelut</a> som är gemensamt för Finlands största städer.",
-  "AboutPageContent.customerRegisterHeader": "Kundregisterbeskrivning",
   "AboutPageContent.customerRegisterLink": "Kundregisterbeskrivning",
-  "AboutPageContent.customerRegisterParagraph": "Tjänstens kundregisterbeskrivning finns här: ",
   "AboutPageContent.defaultHeader": "Information om tjänsten varaamo.hel.fi",
   "AboutPageContent.defaultLead": "Varaamo är en webbtjänst som upprätthålls av Helsingfors stad. Genom den kan man boka stadens offentliga utrymmen och arbetspunkter för privat bruk.",
   "AboutPageContent.defaultReservableParagraph": "I pilotskedet kan man boka stadsbibliotekets, ungdomscentralens och barnomsorgsverkets utrymmen, arbetspunkter och apparater.",

--- a/src/domain/about/AboutPage.js
+++ b/src/domain/about/AboutPage.js
@@ -19,14 +19,6 @@ function AboutPage({ t }) {
         <p>
           <FeedbackLink>{t('AboutPageContent.feedbackLink')}</FeedbackLink>
         </p>
-
-        <h2>{t('AboutPageContent.customerRegisterHeader')}</h2>
-        <p>
-          {t('AboutPageContent.customerRegisterParagraph')}
-          <a href="https://www.tampere.fi/tampereen-kaupunki/yhteystiedot-ja-asiointi/verkkoasiointi/tietosuoja.html">
-            {t('AboutPageContent.customerRegisterLink')}
-          </a>
-        </p>
         <br />
       </div>
     </PageWrapper>

--- a/src/domain/about/__tests__/__snapshots__/AboutPage.test.js.snap
+++ b/src/domain/about/__tests__/__snapshots__/AboutPage.test.js.snap
@@ -22,17 +22,6 @@ exports[`pages/about/AboutPage render normally 1`] = `
         AboutPageContent.feedbackLink
       </FeedbackLink>
     </p>
-    <h2>
-      AboutPageContent.customerRegisterHeader
-    </h2>
-    <p>
-      AboutPageContent.customerRegisterParagraph
-      <a
-        href="https://www.tampere.fi/tampereen-kaupunki/yhteystiedot-ja-asiointi/verkkoasiointi/tietosuoja.html"
-      >
-        AboutPageContent.customerRegisterLink
-      </a>
-    </p>
     <br />
   </div>
 </PageWrapper>

--- a/src/domain/footer/Footer.js
+++ b/src/domain/footer/Footer.js
@@ -58,11 +58,6 @@ function Footer({ t }) {
               {feedbackLink}
             </p>
           </Col>
-          <Col lg={3} md={3} xs={12}>
-            <div className="app-varaamo-version-wrapper">
-              <span className="app-varaamo-version">{`v${version}`}</span>
-            </div>
-          </Col>
         </Row>
       </Grid>
     </footer>

--- a/src/domain/footer/Footer.js
+++ b/src/domain/footer/Footer.js
@@ -19,6 +19,11 @@ function Footer({ t }) {
       {t('AccessibilityPage.pageLink')}
     </Link>
   );
+  const clientRegisterDescriptionLink = (
+    <a href="https://www.tampere.fi/tietosuoja-ja-tiedonhallinta/tietosuojaselosteet">
+      {t('AboutPageContent.customerRegisterLink')}
+    </a>
+  );
 
   let cityNameId;
   switch (getCurrentCustomization()) {
@@ -51,6 +56,9 @@ function Footer({ t }) {
               {t(cityNameId)}
             </p>
             <MunicipalityLogos />
+            <p>
+              {clientRegisterDescriptionLink}
+            </p>
             <p>
               {accessibilityPage}
             </p>

--- a/src/domain/footer/__tests__/__snapshots__/Footer.test.js.snap
+++ b/src/domain/footer/__tests__/__snapshots__/Footer.test.js.snap
@@ -39,6 +39,13 @@ exports[`domain/footer/Footer When there is no customization in use renders corr
         </p>
         <InjectT(MunicipalityLogos) />
         <p>
+          <a
+            href="https://www.tampere.fi/tietosuoja-ja-tiedonhallinta/tietosuojaselosteet"
+          >
+            AboutPageContent.customerRegisterLink
+          </a>
+        </p>
+        <p>
           <Link
             className="feedback-link"
             replace={false}
@@ -96,6 +103,13 @@ exports[`domain/footer/Footer renders correctly 1`] = `
           Footer.helsinkiText
         </p>
         <InjectT(MunicipalityLogos) />
+        <p>
+          <a
+            href="https://www.tampere.fi/tietosuoja-ja-tiedonhallinta/tietosuojaselosteet"
+          >
+            AboutPageContent.customerRegisterLink
+          </a>
+        </p>
         <p>
           <Link
             className="feedback-link"

--- a/src/domain/footer/__tests__/__snapshots__/Footer.test.js.snap
+++ b/src/domain/footer/__tests__/__snapshots__/Footer.test.js.snap
@@ -53,23 +53,6 @@ exports[`domain/footer/Footer When there is no customization in use renders corr
           </FeedbackLink>
         </p>
       </Col>
-      <Col
-        bsClass="col"
-        componentClass="div"
-        lg={3}
-        md={3}
-        xs={12}
-      >
-        <div
-          className="app-varaamo-version-wrapper"
-        >
-          <span
-            className="app-varaamo-version"
-          >
-            v0.12.0
-          </span>
-        </div>
-      </Col>
     </Row>
   </Grid>
 </footer>
@@ -127,23 +110,6 @@ exports[`domain/footer/Footer renders correctly 1`] = `
             Footer.feedbackLink
           </FeedbackLink>
         </p>
-      </Col>
-      <Col
-        bsClass="col"
-        componentClass="div"
-        lg={3}
-        md={3}
-        xs={12}
-      >
-        <div
-          className="app-varaamo-version-wrapper"
-        >
-          <span
-            className="app-varaamo-version"
-          >
-            v0.12.0
-          </span>
-        </div>
       </Col>
     </Row>
   </Grid>

--- a/src/domain/footer/_footer.scss
+++ b/src/domain/footer/_footer.scss
@@ -38,18 +38,4 @@ footer {
   a:hover {
     color: #eee;
   }
-
-  .app-varaamo-version-wrapper {
-    display: flex;
-    justify-content: center;
-  }
-
-  .app-varaamo-version {
-    font-size: $font-size-small;
-    color: $white;
-    text-align: center;
-    @media (min-width: $screen-md-min) {
-      margin-top: 70px;
-    }
-  }
 }


### PR DESCRIPTION
* Remove the version number from the footer
* Remove the text that states varaamo is in pilot phase
* Move the client registration description to footer and update the link
