### PR TITLE
Filter the units by municipality if selected (TAM-142)

### DIFF
--- a/src/domain/search/__tests__/utils.test.js
+++ b/src/domain/search/__tests__/utils.test.js
@@ -49,6 +49,27 @@ describe('src/domain/search/utils.js', () => {
 
       expect(option.label).toEqual(units[0].name.fi);
     });
+
+    test('resources are filtered if municipality is selected', () => {
+      const turkuUnits = [
+        { id: 2, name: { fi: 'C' }, municipality: 'Turku' },
+      ];
+      const tampereUnits = [
+        { id: 1, name: { fi: 'B' }, municipality: 'Tampere' },
+        { id: 3, name: { fi: 'A' }, municipality: 'Tampere' },
+      ];
+      const units = [...turkuUnits, ...tampereUnits];
+
+      let options = searchUtils.getUnitOptions(units, 'fi', 'Turku');
+      expect(options.length).toBe(1);
+      expect(options[0]).toMatchObject({ value: 2 });
+
+      options = searchUtils.getUnitOptions(units, 'fi', 'Tampere');
+      expect(options.length).toBe(2);
+
+      options = searchUtils.getUnitOptions(units, 'fi', 'Turku,Tampere');
+      expect(options.length).toBe(3);
+    });
   });
 
   test('getPurposeOptions', () => {

--- a/src/domain/search/filters/SearchFilters.js
+++ b/src/domain/search/filters/SearchFilters.js
@@ -253,7 +253,7 @@ class SearchFilters extends React.Component {
                     label={t('SearchFilters.unitLabel')}
                     name="app-SearchControls-unit-select"
                     onChange={item => this.onFilterChange('unit', item.value)}
-                    options={searchUtils.getUnitOptions(units, intl.locale)}
+                    options={searchUtils.getUnitOptions(units, intl.locale, municipality)}
                     value={filters.unit}
                   />
                 </Col>

--- a/src/domain/search/utils.js
+++ b/src/domain/search/utils.js
@@ -51,8 +51,15 @@ export const getApiParamsFromFilters = (filters) => {
   return params;
 };
 
-export const getUnitOptions = (units, locale) => {
-  const options = units.map((unit) => {
+export const getUnitOptions = (units, locale, municipality) => {
+  let unitsFilteredByMunicipality = units;
+
+  if (municipality) {
+    const municipalities = municipality.split(',');
+    unitsFilteredByMunicipality = units.filter(unit => municipalities.includes(unit.municipality));
+  }
+
+  const options = unitsFilteredByMunicipality.map((unit) => {
     const finnishName = get(unit, 'name.fi');
 
     return ({


### PR DESCRIPTION
If the municipality is selected, then filter out the units that
belongs to selected municipality in search view.

![unit-municipality-filter](https://user-images.githubusercontent.com/19978017/172859633-c770f4ee-77cd-42c3-a472-131199a647b8.gif)
