### PR TITLE
Render the payable text if the resource needs payment

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -354,6 +354,7 @@
   "ResourceHeader.purpose": "Purpose",
   "ResourceHeader.capacity": "Capacity",
   "ResourceHeader.maxTime": "Max reservation time",
+  "ResourceHeader.payable": "Payable",
   "ResourceHeader.price": "Price",
   "ResourceHeader.premise": "Premise",
   "ResourceHeader.distanceAndPremise": "Distance and premise",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -354,6 +354,7 @@
   "ResourceHeader.purpose": "Käyttötarkoitus",
   "ResourceHeader.capacity": "Kapasiteetti",
   "ResourceHeader.maxTime": "Enimmäisvarausaika",
+  "ResourceHeader.payable": "Maksullinen",
   "ResourceHeader.price": "Hinta",
   "ResourceHeader.premise": "Toimipiste",
   "ResourceHeader.distanceAndPremise": "Etäisyys ja toimipiste",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -357,6 +357,7 @@
   "ResourceHeader.purpose": "Ändamål",
   "ResourceHeader.capacity": "Kapacitet",
   "ResourceHeader.maxTime": "max reserveringstid",
+  "ResourceHeader.payable": "Betala",
   "ResourceHeader.price": "Pris",
   "ResourceHeader.premise": "Utrymmet",
   "ResourceHeader.distanceAndPremise": "Avstånd och utrymmet",

--- a/app/shared/resource-card/__tests__/ResourceCard.test.js
+++ b/app/shared/resource-card/__tests__/ResourceCard.test.js
@@ -220,6 +220,7 @@ describe('shared/resource-card/ResourceCard', () => {
           maxPrice: 0,
           minPrice: 0,
           priceType: 'hourly',
+          freeToUse: true,
         });
         const hourlyPriceSpan = getWrapper({ resource }).find('.app-ResourceCard__hourly-price');
 
@@ -234,11 +235,27 @@ describe('shared/resource-card/ResourceCard', () => {
         const resource = getResource({
           maxPrice: '',
           minPrice: '',
+          freeToUse: true,
         });
         const hourlyPriceSpan = getWrapper({ resource }).find('.app-ResourceCard__hourly-price');
 
         expect(hourlyPriceSpan.is('span')).toBe(true);
         expect(hourlyPriceSpan.text()).toContain('ResourceIcons.free');
+      },
+    );
+
+    test(
+      'renders correct text if resource needs payment but prices are not set',
+      () => {
+        const resource = getResource({
+          maxPrice: '',
+          minPrice: '',
+          freeToUse: false,
+        });
+        const hourlyPriceSpan = getWrapper({ resource }).find('.app-ResourceCard__hourly-price');
+
+        expect(hourlyPriceSpan.is('span')).toBe(true);
+        expect(hourlyPriceSpan.text()).toContain('ResourceHeader.payable');
       },
     );
   });

--- a/app/utils/resourceUtils.js
+++ b/app/utils/resourceUtils.js
@@ -97,8 +97,9 @@ function getAvailabilityDataForWholeDay(resource = {}, date = null) {
   };
 }
 
-function getPrice(t, { minPrice, maxPrice, priceType }) {
-  return genericGetPrice(minPrice, maxPrice, priceType, t);
+// eslint-disable-next-line object-curly-newline
+function getPrice(t, { minPrice, maxPrice, priceType, freeToUse }) {
+  return genericGetPrice(minPrice, maxPrice, priceType, t, freeToUse);
 }
 
 function getHumanizedPeriod(period) {

--- a/src/domain/resource/__tests__/utils.test.js
+++ b/src/domain/resource/__tests__/utils.test.js
@@ -127,14 +127,20 @@ describe('domain resource utility function', () => {
   describe('getPriceFromSnakeCaseResource', () => {
     const fakeT = foo => foo;
     test('return free text if there is no price', () => {
-      const price = resourceUtils.getPriceFromSnakeCaseResource({}, fakeT);
+      const price = resourceUtils.getPriceFromSnakeCaseResource({ free_to_use: true }, fakeT);
       expect(price).toContain('free');
+    });
+
+    test('return payable text if resource is not free and prices are not set', () => {
+      const price = resourceUtils.getPriceFromSnakeCaseResource({ free_to_use: false }, fakeT);
+      expect(price).toBe('ResourceHeader.payable');
     });
 
     test('return free text if price is 0', () => {
       const price = resourceUtils.getPriceFromSnakeCaseResource({
         min_price: '0.00',
         price_type: 'hourly',
+        free_to_use: true,
       }, fakeT);
 
       expect(price).toContain('free');

--- a/src/domain/resource/card/__tests__/__snapshots__/ResourceCard.test.js.snap
+++ b/src/domain/resource/card/__tests__/__snapshots__/ResourceCard.test.js.snap
@@ -100,7 +100,7 @@ exports[`ResourceCard renders correctly 1`] = `
     <ResourceCardInfoCell
       icon="test-file-stub"
       onClick={[Function]}
-      text="ResourceIcons.free"
+      text="ResourceHeader.payable"
     />
     <ResourceCardInfoCell
       icon="test-file-stub"

--- a/src/domain/resource/utils.js
+++ b/src/domain/resource/utils.js
@@ -75,7 +75,7 @@ function getPriceEnding(resourcePriceType, labels) {
   return resourcePriceUnit ? `€/${translatedPriceUnit}` : '€';
 }
 
-export const getPrice = (minPriceString, maxPriceString, priceType, t) => {
+export const getPrice = (minPriceString, maxPriceString, priceType, t, freeToUse) => {
   const minPrice = !isNaN(minPriceString)
     ? Number(minPriceString)
     : minPriceString;
@@ -83,6 +83,11 @@ export const getPrice = (minPriceString, maxPriceString, priceType, t) => {
     ? Number(maxPriceString)
     : maxPriceString;
 
+  /* TODO: When the pricelist feature is implemented, this code needs the
+       modification */
+  if (!freeToUse && !(minPrice || maxPrice)) {
+    return t('ResourceHeader.payable');
+  }
   if (!(minPrice || maxPrice)) {
     return t('ResourceIcons.free');
   }
@@ -114,10 +119,10 @@ export const getPrice = (minPriceString, maxPriceString, priceType, t) => {
  * @returns {string|*}
  */
 export const getPriceFromSnakeCaseResource = (resource, t) => {
-  // eslint-disable-next-line camelcase
-  const { min_price, max_price, price_type } = resource;
+  // eslint-disable-next-line camelcase, object-curly-newline
+  const { min_price, max_price, price_type, free_to_use } = resource;
 
-  return getPrice(min_price, max_price, price_type, t);
+  return getPrice(min_price, max_price, price_type, t, free_to_use);
 };
 
 /**


### PR DESCRIPTION
If the resource is not free i.e. needs payment but the payment
amounts are missing, render 'Payable' text.

This is a temporary fix for now. All the prices for the resource
will come from a pricelist later.


