### PR TITLE
Hide the reservation calendar if resource doesn't have calendar (TAM-170)

### DIFF
--- a/app/pages/resource/ResourcePage.js
+++ b/app/pages/resource/ResourcePage.js
@@ -344,7 +344,7 @@ class UnconnectedResourcePage extends Component {
                                 />
                               </form>
                             )}
-                            {!resource.externalReservationUrl && (
+                            {!resource.canOnlyBeReservedExternally && (
                               <div>
                                 {window.innerWidth < 768 && (
                                   <React.Fragment>

--- a/app/utils/fixtures/Resource.js
+++ b/app/utils/fixtures/Resource.js
@@ -24,5 +24,6 @@ const Resource = new Factory()
   .attr('shouldBeReservedWholeDay', false)
   .attr('authentication', 'none')
   .attr('placement', '')
+  .attr('canOnlyBeReservedExternally', false)
   .attr('area', 13);
 export default Resource;


### PR DESCRIPTION
Hide the reservation calendar for following cases:
* If the reservation is made externally
* If the resource doesn't have valid period
* If the unit doesn't have valid period

** This needs https://github.com/andersinno/respa/pull/90