### PR TITLE
Modify conditions for showing the resource reservation panel

### DIFF
--- a/app/pages/resource/ResourcePage.js
+++ b/app/pages/resource/ResourcePage.js
@@ -287,6 +287,10 @@ class UnconnectedResourcePage extends Component {
     const mainImageIndex = findIndex(images, image => image.type === 'main');
     const mainImage = mainImageIndex != null ? images[mainImageIndex] : null;
     const showBackButton = !!location.state && !!location.state.fromSearchResults;
+    const showResourcePanel = resource.reservable && (
+      (resource.canOnlyBeReservedExternally && resource.externalReservationUrl)
+      || (!resource.canOnlyBeReservedExternally)
+    );
     const resourceReservationButton = (
       <ResourceReservationButton
         isLoggedIn={isLoggedIn}
@@ -332,7 +336,7 @@ class UnconnectedResourcePage extends Component {
                     />
 
                     {
-                      resource.reservable && (
+                      showResourcePanel && (
                         <ResourcePanel header={t('ResourceInfo.reserveTitle')}>
                           <>
                             {resource.externalReservationUrl && (


### PR DESCRIPTION
In the resource view, do not show the 'Reserve' section at all if the resource is only externally reservable but doesn't have an external link.

i.e. the "Reserve" section will now only be shown if
- The resource can be reversed from Varaamo or
- The resource is only reservable externally and has a link for the external registration

<img width="1528" alt="image" src="https://user-images.githubusercontent.com/5648062/207601785-32cd6377-3787-4ca4-86bd-187ca2449ebd.png">


Refs TAM-170