### PR TITLE
Do not show "payable" message if min or max price is zero

### DIFF
--- a/src/domain/resource/utils.js
+++ b/src/domain/resource/utils.js
@@ -83,12 +83,7 @@ export const getPrice = (minPriceString, maxPriceString, priceType, t, freeToUse
     ? Number(maxPriceString)
     : maxPriceString;
 
-  /* TODO: When the pricelist feature is implemented, this code needs the
-       modification */
-  if (!freeToUse && !(minPrice || maxPrice)) {
-    return t('ResourceHeader.payable');
-  }
-  if (!(minPrice || maxPrice)) {
+  if (freeToUse || !(minPrice || maxPrice)) {
     return t('ResourceIcons.free');
   }
 


### PR DESCRIPTION
The "free" ("Maksuton") message should be shown if the resource is free to use, or if min and max price are both zero or null.
