### PR TITLE
Show tax percentage in reservation confirmation page (TTVA-52)

### DIFF
--- a/app/pages/reservation/reservation-confirmation/ReservationConfirmation.js
+++ b/app/pages/reservation/reservation-confirmation/ReservationConfirmation.js
@@ -52,6 +52,7 @@ class ReservationConfirmation extends Component {
       failedReservations, isEdited, reservation, resource, t, user,
     } = this.props;
     const reservationPrice = reservation.priceInfo && reservation.priceInfo.totalPrice;
+    const reservationTaxPct = reservation.priceInfo && reservation.priceInfo.taxPercentage;
     const { needManualConfirmation } = reservation;
 
     const href = `${constants.FEEDBACK_URL}`;
@@ -161,7 +162,10 @@ class ReservationConfirmation extends Component {
               && this.renderField(
                 'reservationPrice',
                 t('common.totalPriceLabel'),
-                `${reservationPrice}€`,
+                t('common.priceWithVAT', {
+                  price: reservationPrice,
+                  vat: reservationTaxPct,
+                }),
               )}
             {reservation.reserverName
               && this.renderField(


### PR DESCRIPTION
Show the tax percentage with the price information in the reservation confirmation page that is shown after payment.

<img width="1472" alt="Screenshot 2023-05-08 at 15 08 23" src="https://user-images.githubusercontent.com/5648062/236821021-28de640b-1616-47fb-9069-e5804603f4e0.png">


Refs TTVA-52