### PR TITLE
Show payment link button in user reservations

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -263,6 +263,7 @@
   "ReservationControls.deny": "Deny",
   "ReservationControls.edit": "Edit",
   "ReservationControls.info": "Information",
+  "ReservationControls.pay": "Pay",
   "ReservationEditForm.priceWithTax": "{price}€ (inc VAT {tax}%)",
   "ReservationEditForm.cancelEdit": "Cancel editing",
   "ReservationEditForm.saveChanges": "Save changes",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -263,6 +263,7 @@
   "ReservationControls.deny": "Hylkää",
   "ReservationControls.edit": "Muokkaa",
   "ReservationControls.info": "Tiedot",
+  "ReservationControls.pay": "Maksa",
   "ReservationEditForm.priceWithTax": "{price}€ (sis. ALV {tax}%)",
   "ReservationEditForm.cancelEdit": "Peruuta muokkaus",
   "ReservationEditForm.saveChanges": "Tallenna muutokset",

--- a/app/pages/user-reservations/reservation-list/ReservationListItem.js
+++ b/app/pages/user-reservations/reservation-list/ReservationListItem.js
@@ -16,7 +16,6 @@ import { getMainImage } from '../../../utils/imageUtils';
 import { getResourcePageUrl, hasProducts } from '../../../utils/resourceUtils';
 import {
   getReservationPrice,
-  getTaxPercentage,
 } from '../../../../src/domain/resource/utils';
 
 class ReservationListItem extends Component {

--- a/app/shared/reservation-controls/ReservationControls.js
+++ b/app/shared/reservation-controls/ReservationControls.js
@@ -9,6 +9,9 @@ import { getUnitRoleFromResource, getIsUnitStaff } from '../../../src/domain/res
 
 class ReservationControls extends Component {
   get buttons() {
+    const { reservation } = this.props;
+    const paymentLink = reservation.payment_link;
+
     return {
       cancel: (
         <Button
@@ -62,6 +65,16 @@ class ReservationControls extends Component {
           {this.props.t('ReservationControls.info')}
         </Button>
       ),
+      pay: paymentLink && (
+        <Button
+          bsStyle="success"
+          href={paymentLink}
+          key="payButton"
+        >
+          {this.props.t('ReservationControls.pay')}
+        </Button>
+      ),
+
     };
   }
 
@@ -82,7 +95,7 @@ class ReservationControls extends Component {
       }
       return isAdmin
         ? [buttons.edit, buttons.cancel]
-        : [buttons.edit, buttons.cancel];
+        : [buttons.pay, buttons.edit, buttons.cancel];
     }
 
     switch (reservation.state) {


### PR DESCRIPTION
https://andersinno.atlassian.net/jira/software/c/projects/TTVA/boards/11?modal=detail&selectedIssue=TTVA-81

If "payment_link" is not null, then show the link in a "Pay" button in the user reservations list.

The payment link logic is handled by Respa API, so it should not be shown e.g. for reservations that are confirmed or cancelled.

The payment link should also not be shown when manual confirmation is required or the user is admin of the resource/unit. This logic might need to be revisited when we allow normal payments for staff members.

Refs TTVA-81