### PR TITLE
Do not show payment time limit note for preliminary reservations (TTVA-93)

### DIFF
--- a/app/pages/reservation/reservation-information/ReservationInformationForm.js
+++ b/app/pages/reservation/reservation-information/ReservationInformationForm.js
@@ -269,7 +269,7 @@ class UnconnectedReservationInformationForm extends Component {
   renderPaymentTimeLimitNote = () => {
     const { t } = this.props;
     return (
-      <div className="wrapped-text">
+      <div className="wrapped-text payment-time-limit-note">
         {t('common.paymentTimeLimitNote')}
       </div>
     );
@@ -280,12 +280,13 @@ class UnconnectedReservationInformationForm extends Component {
       isMakingReservations,
       isPayableAmount,
       isPaymentRequired,
+      resource,
       t,
     } = this.props;
 
     let buttonText;
 
-    if (isPaymentRequired && isPayableAmount) {
+    if (isPaymentRequired && isPayableAmount && !resource.needManualConfirmation) {
       buttonText = t('common.pay');
     } else if (isMakingReservations) {
       buttonText = t('common.saving');
@@ -322,6 +323,8 @@ class UnconnectedReservationInformationForm extends Component {
     } = this.props;
     const userGroupOptions = this.getReservationUserGroups(resource);
     const eventTypeOptions = this.getReservationEventTypes(resource);
+
+    const showPaymentTimeLimitNote = isPaymentRequired && isPayableAmount && !resource.needManualConfirmation;
 
     return (
       <div>
@@ -593,7 +596,7 @@ class UnconnectedReservationInformationForm extends Component {
               {this.renderTermsField('specificTerms')}
             </div>
           )}
-          {isPaymentRequired && isPayableAmount && this.renderPaymentTimeLimitNote()}
+          {showPaymentTimeLimitNote && this.renderPaymentTimeLimitNote()}
           <div>
             <Button
               onClick={onCancel}

--- a/app/pages/reservation/reservation-information/__tests__/ReservationInformationForm.test.js
+++ b/app/pages/reservation/reservation-information/__tests__/ReservationInformationForm.test.js
@@ -246,6 +246,42 @@ describe('pages/reservation/reservation-information/ReservationInformationForm',
       });
     });
 
+    describe('payment time limit note', () => {
+      describe('when payable reservation does not require manual confirmation', () => {
+        test('renders payment time limit note', () => {
+          const resource = Resource.build({
+            needManualConfirmation: false,
+          });
+          const props = {
+            isPayableAmount: true,
+            isPaymentRequired: true,
+            resource,
+          };
+          const wrapper = getWrapper(props);
+          const text = wrapper.find('.payment-time-limit-note');
+
+          expect(text).toHaveLength(1);
+        });
+      });
+
+      describe('when payable reservation requires manual confirmation', () => {
+        test('does not render payment time limit note', () => {
+          const resource = Resource.build({
+            needManualConfirmation: true,
+          });
+          const props = {
+            isPayableAmount: true,
+            isPaymentRequired: true,
+            resource,
+          };
+          const wrapper = getWrapper(props);
+          const text = wrapper.find('.payment-time-limit-note');
+
+          expect(text).toHaveLength(0);
+        });
+      });
+    });
+
     describe('form buttons', () => {
       describe('when is editing is false', () => {
         const buttons = getWrapper({ isEditing: false }).find(Button);


### PR DESCRIPTION
- Only render the payment time limit note if the (payable) reservation does not require manual confirmation.
- Render the 'Pay' button text only if the reservation does not require manual confirmation.
- Add tests for the payment time limit text rendering.

Refs TTVA-93