### PR TITLE
Use the same PAGE_SIZE parameter for Excel/CSV downloads

### DIFF
--- a/src/domain/reservation/manage/filters/ManageReservationsFilters.js
+++ b/src/domain/reservation/manage/filters/ManageReservationsFilters.js
@@ -31,6 +31,7 @@ class ManageReservationsFilters extends React.Component {
     onShowOnlyFiltersChange: PropTypes.func.isRequired,
     onReservationDownload: PropTypes.func.isRequired,
     showOnlyFilters: PropTypes.array,
+    showDownload: PropTypes.bool,
     intl: intlShape,
   };
 
@@ -148,6 +149,7 @@ class ManageReservationsFilters extends React.Component {
       intl,
       onShowOnlyFiltersChange,
       showOnlyFilters,
+      showDownload,
     } = this.props;
 
     const state = get(filters, 'state', null);
@@ -241,6 +243,7 @@ class ManageReservationsFilters extends React.Component {
               )}
             </Col>
           </Row>
+          {showDownload && (
           <Row>
             <Col md={6}>
               <SelectField
@@ -262,6 +265,7 @@ class ManageReservationsFilters extends React.Component {
               </Button>
             </Col>
           </Row>
+          )}
         </Grid>
       </div>
     );

--- a/src/domain/reservation/manage/filters/__tests__/ManageReservationsFilters.test.js
+++ b/src/domain/reservation/manage/filters/__tests__/ManageReservationsFilters.test.js
@@ -12,6 +12,7 @@ describe('ManageReservationsFilters', () => {
       units: [unit.build()],
       onSearchChange: jest.fn(),
       onShowOnlyFiltersChange: jest.fn(),
+      showDownload: true,
     };
     const wrapper = shallowWithIntl(
       <UnwrappedManageReservationsFilters {...props} />,

--- a/src/domain/reservation/manage/page/ManageReservationsPage.js
+++ b/src/domain/reservation/manage/page/ManageReservationsPage.js
@@ -29,6 +29,7 @@ import ConnectedReservationCancelModal from '../../modal/ReservationCancelModal'
 import { createPaymentReturnUrl } from '../../../../../app/utils/resourceUtils';
 
 export const PAGE_SIZE = 50;
+
 const INITIAL_SELECTED_RESERVATION_RESOURCE = {
   data: null,
   isLoading: false,
@@ -296,6 +297,7 @@ class ManageReservationsPage extends React.Component {
 
   downloadReservationData = (downloadType) => {
     const { location } = this.props;
+    const { totalCount } = this.state;
     const filters = searchUtils.getFiltersFromUrl(location, false);
     const params = { ...filters, excludeReservationExtraFields: 1 };
     const fileName = `reservation_${Date.now()}`;
@@ -314,7 +316,11 @@ class ManageReservationsPage extends React.Component {
         'responseType': 'blob',
       },
     };
-    client.get('reservation', params, config).then(
+
+    client.get('reservation', {
+      ...params,
+      page_size: totalCount,
+    }, config).then(
       (response) => {
         const url = window.URL.createObjectURL(new Blob([response.data]));
         const link = document.createElement('a');

--- a/src/domain/reservation/manage/page/ManageReservationsPage.js
+++ b/src/domain/reservation/manage/page/ManageReservationsPage.js
@@ -38,11 +38,11 @@ const INITIAL_SELECTED_RESERVATION_RESOURCE = {
 
 class ManageReservationsPage extends React.Component {
   static propTypes = {
-    isAdmin: PropTypes.bool,
-    t: PropTypes.func.isRequired,
-    history: PropTypes.object,
-    location: PropTypes.object,
     actions: PropTypes.object,
+    history: PropTypes.object,
+    isAdmin: PropTypes.bool,
+    location: PropTypes.object,
+    t: PropTypes.func.isRequired,
     userFavoriteResources: PropTypes.array,
   };
 
@@ -354,6 +354,8 @@ class ManageReservationsPage extends React.Component {
     const filters = searchUtils.getFiltersFromUrl(location, false);
     const title = t('ManageReservationsPage.title');
 
+    const showDownload = !!totalCount;
+
     return (
       <div className="app-ManageReservationsPage">
         <div className="app-ManageReservationsPage__filters">
@@ -369,6 +371,7 @@ class ManageReservationsPage extends React.Component {
             onReservationDownload={this.downloadReservationData}
             onSearchChange={this.onSearchFiltersChange}
             onShowOnlyFiltersChange={this.onShowOnlyFiltersChange}
+            showDownload={showDownload}
             showOnlyFilters={showOnlyFilters}
             units={units}
           />

--- a/src/domain/reservation/manage/page/__tests__/__snapshots__/ManageReservationsPage.test.js.snap
+++ b/src/domain/reservation/manage/page/__tests__/__snapshots__/ManageReservationsPage.test.js.snap
@@ -36,6 +36,7 @@ exports[`ManageReservationsPage renders correctly 1`] = `
       onReservationDownload={[Function]}
       onSearchChange={[Function]}
       onShowOnlyFiltersChange={[Function]}
+      showDownload={false}
       showOnlyFilters={
         Array [
           "can_modify",


### PR DESCRIPTION
Sets the "page_size" parameter to be the total count of all reservations available to the user e.g. if total count is 100, then the Excel/CSV download should have 100 rows.

The download controls are only shown if/when total count available.
