### PR TITLE
Add note about manual confirmation to reservation info page (TTVA-92)

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -309,6 +309,8 @@
   "ReservationInfo.reservationMinLength": "Minimum duration of the reservation:",
   "ReservationInfo.reservationEarliestDays": "Reservation must be made {time} in advance",
   "ReservationInfo.reservationLatestDays": "Reservations can be made {time} in advance, until {date}",
+  "ReservationInfo.requiresManualConfirmation": "Reservation requires manual confirmation",
+  "ReservationInfo.iconClockAlt": "Clock",
   "ReservationInfoModal.cancelButton": "Cancel event",
   "ReservationInfoModal.approveButton": "Approve reservation",
   "ReservationInfoModal.denyButton": "Deny reservation",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -309,6 +309,8 @@
   "ReservationInfo.reservationMinLength": "Varauksen vähimmäispituus:",
   "ReservationInfo.reservationEarliestDays": "Varattava vähintään {time} etukäteen",
   "ReservationInfo.reservationLatestDays": "Varauksen voi tehdä {time} etukäteen, {date} asti",
+  "ReservationInfo.requiresManualConfirmation": "Varaus vaatii virkailijan vahvistuksen",
+  "ReservationInfo.iconClockAlt": "Kello",
   "ReservationInfoModal.cancelButton": "Peru varaus",
   "ReservationInfoModal.approveButton": "Hyväksy varaus",
   "ReservationInfoModal.denyButton": "Hylkää varaus",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -301,6 +301,8 @@
   "ReservationInfo.reservationMinLength": "Minsta längd av bokningen:",
   "ReservationInfo.reservationEarliestDays": "Bokning måste göras {time} i förväg",
   "ReservationInfo.reservationLatestDays": "Bokningar kan göras {time} i förväg, fram tills {date}",
+  "ReservationInfo.requiresManualConfirmation": "Bokning kräver manuell bekräftelse",
+  "ReservationInfo.iconClockAlt": "Klockan",
   "ReservationInfoModal.cancelButton": "Annulera evenmanget",
   "ReservationInfoModal.approveButton": "Bekräfta reserveringen",
   "ReservationInfoModal.denyButton": "Förneka reserveringen",

--- a/app/pages/resource/reservation-info/ReservationInfo.js
+++ b/app/pages/resource/reservation-info/ReservationInfo.js
@@ -117,10 +117,20 @@ function renderReservationPeriodInfo(resource, t) {
   );
 }
 
+function renderRequiresManualConfirmationText(t) {
+  return (
+    <p className="needs-manual-confirmation-text">
+      <img alt={t('ReservationInfo.iconClockAlt')} className="app-ResourceHeader__info-icon" src={iconClock} />
+      <strong>{t('ReservationInfo.requiresManualConfirmation')}</strong>
+    </p>
+  );
+}
+
 function ReservationInfo({ isLoggedIn, resource, t }) {
   return (
     <div className="app-ReservationInfo">
       <WrappedText openLinksInNewTab text={resource.reservationInfo} />
+      {resource.needManualConfirmation && renderRequiresManualConfirmationText(t)}
       {renderEarliestResDay(resource, t)}
       {renderLastResDay(resource, t)}
       {renderReservationPeriodInfo(resource, t)}

--- a/app/pages/resource/reservation-info/__tests__/ReservationInfo.test.js
+++ b/app/pages/resource/reservation-info/__tests__/ReservationInfo.test.js
@@ -148,4 +148,24 @@ describe('pages/resource/reservation-info/ReservationInfo', () => {
       },
     );
   });
+
+  describe('requires manual confirmation text', () => {
+    test(
+      'is rendered correctly when resource.needManualConfirmation is true',
+      () => {
+        const resource = { needManualConfirmation: true };
+        const requiresManualConfirmationText = getWrapper({ resource }).find('.needs-manual-confirmation-text');
+        expect(requiresManualConfirmationText).toHaveLength(1);
+      },
+    );
+
+    test(
+      'is not rendered if resource.needManualConfirmation is not true',
+      () => {
+        const resource = { needManualConfirmation: false };
+        const requiresManualConfirmationText = getWrapper({ resource }).find('.needs-manual-confirmation-text');
+        expect(requiresManualConfirmationText).toHaveLength(0);
+      },
+    );
+  });
 });


### PR DESCRIPTION
If the resource requires manual confirmation, show it in reservation details section in the reservation information view.

<img width="1429" alt="Screenshot 2023-05-23 at 14 08 20" src="https://github.com/andersinno/varaamo/assets/5648062/861b8dbc-1d82-4dd5-ad96-6dc42aab6c13">

Refs TTVA-92
