### PR TITLE
Make event type selection required

### DIFF
--- a/app/pages/reservation/reservation-information/ReservationInformation.js
+++ b/app/pages/reservation/reservation-information/ReservationInformation.js
@@ -49,6 +49,7 @@ class ReservationInformation extends Component {
       resource,
     } = this.props;
     const formFields = [...resource.supportedReservationExtraFields].map(value => camelCase(value));
+    const eventTypes = resource.pricingEventTypes ? [...resource.pricingEventTypes] : [];
 
     if (isAdmin) {
       formFields.push('comments');
@@ -83,7 +84,9 @@ class ReservationInformation extends Component {
         formFields.push('billingEmailAddress');
       }
       formFields.push('userGroup');
-      formFields.push('eventType');
+      if (eventTypes.length > 0) {
+        formFields.push('eventType');
+      }
     }
 
     return uniq(formFields);
@@ -128,6 +131,7 @@ class ReservationInformation extends Component {
 
     requiredFormFields.push('paymentTermsAndConditions');
     requiredFormFields.push('userGroup');
+    requiredFormFields.push('eventType');
 
     if (!isAdmin) {
       requiredFormFields.push('billingFirstName');

--- a/app/pages/reservation/reservation-information/ReservationInformationForm.js
+++ b/app/pages/reservation/reservation-information/ReservationInformationForm.js
@@ -378,13 +378,13 @@ class UnconnectedReservationInformationForm extends Component {
                   )}
                 </div>
               )}
-              {includes(fields, 'eventType') && (eventTypeOptions.length > 0) && (
+              {includes(fields, 'eventType') && (
                 <div>
                   {this.renderDropDown(
                     'eventType',
                     t('ReservationInformationForm.eventType'),
                     eventTypeOptions,
-                    false,
+                    true,
                   )}
                 </div>
               )}

--- a/app/pages/reservation/reservation-information/__tests__/ReservationInformation.test.js
+++ b/app/pages/reservation/reservation-information/__tests__/ReservationInformation.test.js
@@ -69,7 +69,7 @@ describe('pages/reservation/reservation-information/ReservationInformation', () 
   });
 
   describe('getFormFields', () => {
-    const resource = Resource.build({
+    let resource = Resource.build({
       needManualConfirmation: true,
       supportedReservationExtraFields: ['some_field_1', 'some_field_2'],
     });
@@ -115,6 +115,29 @@ describe('pages/reservation/reservation-information/ReservationInformation', () 
       const actual = instance.getFormFields(termsAndConditions);
 
       expect(actual).toEqual([...supportedFields, 'termsAndConditions']);
+    });
+
+    test('returns eventType field when there are event type specific prices', () => {
+      resource = Resource.build({
+        pricingEventTypes: [{
+          id: 1,
+          name: 'Event type 1',
+        }],
+      });
+      const wrapper = getWrapper({ isPaymentRequired: true, resource });
+      const actual = wrapper.instance().getFormFields();
+
+      expect(actual).toEqual(expect.arrayContaining(['eventType']));
+    });
+
+    test('does not return eventType field when there are no event type specific prices', () => {
+      resource = Resource.build({
+        pricingEventTypes: [],
+      });
+      const wrapper = getWrapper({ isPaymentRequired: true, resource });
+      const actual = wrapper.instance().getFormFields();
+
+      expect(actual).not.toEqual(expect.arrayContaining(['eventType']));
     });
   });
 
@@ -178,6 +201,7 @@ describe('pages/reservation/reservation-information/ReservationInformation', () 
     const paymentFields = [
       'paymentTermsAndConditions',
       'userGroup',
+      'eventType',
     ];
 
     test('returns correct required form fields', () => {


### PR DESCRIPTION
In the reservation form, if the resource has a price list with event type specific prices, make the event type selection required.

<img width="1392" alt="image" src="https://github.com/andersinno/varaamo/assets/5648062/18fb027a-eead-4d04-a763-1de70a8fff89">


Refs TTVA-96