### PR TITLE
Add 'None of the above' event type option (TTVA-99)

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -319,6 +319,7 @@
   "ReservationInformationForm.cancelEdit": "Cancel edit",
   "ReservationInformationForm.eventInformationTitle": "Event information",
   "ReservationInformationForm.eventType": "Event type",
+  "ReservationInformationForm.noneOfTheAboveOptionLabel": "None of the above",
   "ReservationInformationForm.paymentTermsAndConditionsLabel": "I have read and accepted",
   "ReservationInformationForm.paymentTermsAndConditionsLink": "payment terms and conditions",
   "ReservationInformationForm.refundCheckBox": " I have read refund instructions.",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -319,6 +319,7 @@
   "ReservationInformationForm.cancelEdit": "Keskeytä muokkaus",
   "ReservationInformationForm.eventInformationTitle": "Tilaisuuden tiedot",
   "ReservationInformationForm.eventType": "Käyttötarkoitus",
+  "ReservationInformationForm.noneOfTheAboveOptionLabel": "Ei mikään edellisistä",
   "ReservationInformationForm.paymentTermsAndConditionsLabel": "Olen lukenut ja hyväksynyt",
   "ReservationInformationForm.paymentTermsAndConditionsLink": "maksuehdot",
   "ReservationInformationForm.refundCheckBox": "Olen lukenut rahojen palautus ohjeet.",

--- a/app/pages/reservation/reservation-information/ReservationInformationForm.js
+++ b/app/pages/reservation/reservation-information/ReservationInformationForm.js
@@ -140,7 +140,8 @@ class UnconnectedReservationInformationForm extends Component {
     return t('ReservationForm.reservationFieldsAsteriskNormal');
   };
 
-  getReservationUserGroups = (resource) => {
+  getUserGroupOptions = () => {
+    const { resource } = this.props;
     const reservationUserGroups = resource.pricingUserGroups ? [...resource.pricingUserGroups] : [];
     const reservationUserGroupOptions = [...reservationUserGroups].map(userGroup => (
       { value: userGroup.id, label: userGroup.name }
@@ -148,7 +149,8 @@ class UnconnectedReservationInformationForm extends Component {
     return reservationUserGroupOptions;
   }
 
-  getReservationEventTypes = (resource) => {
+  getEventTypeOptions = () => {
+    const { resource, t } = this.props;
     const reservationEventTypes = resource.pricingEventTypes ? [...resource.pricingEventTypes] : [];
     if (isEmpty(reservationEventTypes)) {
       return [];
@@ -156,6 +158,11 @@ class UnconnectedReservationInformationForm extends Component {
     const eventTypeOptions = [...reservationEventTypes].map(eventType => (
       { value: eventType.id, label: eventType.name }
     ));
+
+    // Add "None of the above" as the last option. This option does not affect the price
+    // but the user is still required to select it if none of the other options apply.
+    eventTypeOptions.push({ value: null, label: t('ReservationInformationForm.noneOfTheAboveOptionLabel') });
+
     return eventTypeOptions;
   }
 
@@ -321,8 +328,8 @@ class UnconnectedReservationInformationForm extends Component {
       isStaff,
       valid,
     } = this.props;
-    const userGroupOptions = this.getReservationUserGroups(resource);
-    const eventTypeOptions = this.getReservationEventTypes(resource);
+    const userGroupOptions = this.getUserGroupOptions();
+    const eventTypeOptions = this.getEventTypeOptions();
 
     const showPaymentTimeLimitNote = isPaymentRequired && isPayableAmount && !resource.needManualConfirmation;
 

--- a/app/pages/reservation/reservation-information/__tests__/ReservationInformationForm.test.js
+++ b/app/pages/reservation/reservation-information/__tests__/ReservationInformationForm.test.js
@@ -282,6 +282,28 @@ describe('pages/reservation/reservation-information/ReservationInformationForm',
       });
     });
 
+    describe('event type options', () => {
+      test('includes none of the above option', () => {
+        const resource = Resource.build({
+          pricingEventTypes: [{
+            id: 1,
+            name: 'Event type 1',
+          }],
+        });
+        const props = {
+          isPayableAmount: true,
+          isPaymentRequired: true,
+          resource,
+        };
+        const wrapper = getWrapper(props);
+        const instance = wrapper.instance();
+        const options = instance.getEventTypeOptions(resource);
+
+        expect(options).toHaveLength(2);
+        expect(options.pop().label).toBe('ReservationInformationForm.noneOfTheAboveOptionLabel');
+      });
+    });
+
     describe('form buttons', () => {
       describe('when is editing is false', () => {
         const buttons = getWrapper({ isEditing: false }).find(Button);


### PR DESCRIPTION
In the reservation form, add a 'None of the above' option to the event type selection options. Selecting this option does not affect the pricing but forces the user to explicitly select it if none of the other options apply.

Also, do some code refactoring.

<img width="1398" alt="image" src="https://github.com/andersinno/varaamo/assets/5648062/f3c98819-834c-457b-8122-a16a3b86df34">


Refs TTVA-99