### PR TITLE
Select only slots available after current time

### DIFF
--- a/src/common/calendar/TimePickerCalendar.js
+++ b/src/common/calendar/TimePickerCalendar.js
@@ -180,9 +180,22 @@ class TimePickerCalendar extends Component {
           NOTIFICATION_TYPE.INFO, t('TimePickerCalendar.info.shouldBeReservedWholeDayText'),
         );
       }
+
       const startMoment = moment(selected.start).toJSON();
       const selectedDate = startMoment.split('T')[0];
-      const slots = this.getSlotsForDate(selectedDate, resource);
+
+      // select slots from next exact hour
+      // e.g. if time now 11:40, next available slot should be 12:00
+      // even if exact hour, add one hour to prevent server validation rejecting
+      // time earlier than current
+      const minTime = moment().add(1, 'hour').startOf('hour');
+
+      const slots = this.getSlotsForDate(selectedDate, resource).filter(
+        (slot) => {
+          return slot && moment(slot.end).isAfter(minTime);
+        },
+      );
+
       selectable = {
         start: moment(slots[slots.length - 1].start).toDate(),
         // Add 1 millisecond to round the hour/minute
@@ -282,6 +295,7 @@ class TimePickerCalendar extends Component {
         return [selectable, true];
       }
     }
+
     return [selected, false];
   }
 

--- a/src/common/calendar/__tests__/TimePickerCalendar.test.js
+++ b/src/common/calendar/__tests__/TimePickerCalendar.test.js
@@ -61,6 +61,35 @@ describe('Calendar reservation selection', () => {
     expect(wholeDayReservationHours.start.toJSON()).toBe(wholeDayResourceOpeningHours[0].opens);
     expect(wholeDayReservationHours.end.toJSON()).toBe(wholeDayResourceOpeningHours[0].closes);
   });
+
+  test('fills entire opening hours if resource should be reserved for whole day if same day', () => {
+    Date.now = jest.fn(() => new Date('2019-12-17T13:00:00+03:00'));
+
+    const wholeDayResourceOpeningHours = [{
+      date: '2019-12-17',
+      opens: '2019-12-17T09:30:00.000Z',
+      closes: '2019-12-17T17:00:00.000Z',
+    }];
+
+    // should round to next whole exact hour
+    const expected = {
+      date: '2019-12-17',
+      opens: '2019-12-17T11:00:00.000Z',
+      closes: '2019-12-17T17:00:00.000Z',
+    };
+
+    const wholeDayResource = resource.build({
+      should_be_reserved_whole_day: true,
+      min_period: '04:30:00',
+      opening_hours: wholeDayResourceOpeningHours,
+    });
+    const wholeDayResourceWrapper = getWrapper({ resource: wholeDayResource, date: '2019-12-17' });
+    const instance = wholeDayResourceWrapper.instance();
+    const wholeDayReservationHours = instance.getSelectableTimeRange(selectedInvalidSlot);
+
+    expect(wholeDayReservationHours.start.toJSON()).toBe(expected.opens);
+    expect(wholeDayReservationHours.end.toJSON()).toBe(expected.closes);
+  });
 });
 
 


### PR DESCRIPTION
In whole-day only reservations, select only those slots that are after current time (rounded up to next exact hour).

Refs TTVA-94