### PR TITLE
Make sure correct state is sent when reservation is approved (TTVA-100)

### DIFF
--- a/app/actions/reservationActions.js
+++ b/app/actions/reservationActions.js
@@ -12,6 +12,9 @@ import {
   getSuccessTypeDescriptor,
 } from '../utils/apiUtils';
 import { getMissingValues, isStaffEvent } from '../utils/reservationUtils';
+import { RESERVATION_STATE } from '../../src/constants/ReservationState';
+import { getApprovedState } from '../../src/domain/reservation/utils';
+import { createPaymentReturnUrl } from '../utils/resourceUtils';
 
 function commentReservation(reservation, resource, comments) {
   const missingValues = getMissingValues(reservation);
@@ -26,7 +29,13 @@ function commentReservation(reservation, resource, comments) {
 }
 
 function confirmPreliminaryReservation(reservation) {
-  return putReservation(Object.assign({}, reservation, { state: 'confirmed' }));
+  const newState = getApprovedState(decamelizeKeys(reservation));
+  const newValues = { state: newState };
+  // if payment is required we should include the payment return URL in the payload
+  if (newState === RESERVATION_STATE.WAITING_FOR_PAYMENT) {
+    newValues.payment_return_url = createPaymentReturnUrl();
+  }
+  return putReservation(Object.assign({}, reservation, newValues));
 }
 
 function deleteReservation(reservation) {

--- a/src/domain/reservation/__tests__/utils.test.js
+++ b/src/domain/reservation/__tests__/utils.test.js
@@ -3,6 +3,7 @@ import {
   canUserCancelReservation,
   getNextReservationForToday,
   getShowRefundPolicy,
+  getApprovedState,
 } from '../utils';
 import reservationGenerator from '../../../common/data/fixtures/reservation';
 import { RESERVATION_STATE } from '../../../constants/ReservationState';
@@ -85,6 +86,51 @@ describe('Reservation utils function ', () => {
       };
 
       expect(getShowRefundPolicy(true, reservation));
+    });
+  });
+
+  describe('getApprovedState', () => {
+    test('should return RESERVATION_STATE.WAITING_FOR_PAYMENT if reservation requires payment', () => {
+      const reservation = {
+        need_manual_confirmation: true,
+        begin: new Date(2017, 6, 7, 10, 0, 0, 0),
+        end: new Date(2017, 6, 7, 11, 0, 0, 0),
+        price_info: {
+          total_price: 20.00,
+          amount: 20.00,
+          tax_percentage: 24.00,
+          type: 'fixed',
+        },
+      };
+
+      expect(getApprovedState(reservation)).toBe(RESERVATION_STATE.WAITING_FOR_PAYMENT);
+    });
+
+    test('should return RESERVATION_STATE.CONFIRMED if reservation does not require manual confirmation', () => {
+      const reservation = {
+        need_manual_confirmation: false,
+        begin: new Date(2017, 6, 7, 10, 0, 0, 0),
+        end: new Date(2017, 6, 7, 11, 0, 0, 0),
+        price_info: {
+          total_price: 20.00,
+          amount: 20.00,
+          tax_percentage: 24.00,
+          type: 'fixed',
+        },
+      };
+
+      expect(getApprovedState(reservation)).toBe(RESERVATION_STATE.CONFIRMED);
+    });
+
+    test('should return RESERVATION_STATE.CONFIRMED if reservation does not have price info', () => {
+      const reservation = {
+        need_manual_confirmation: true,
+        begin: new Date(2017, 6, 7, 10, 0, 0, 0),
+        end: new Date(2017, 6, 7, 11, 0, 0, 0),
+        price_info: {},
+      };
+
+      expect(getApprovedState(reservation)).toBe(RESERVATION_STATE.CONFIRMED);
     });
   });
 

--- a/src/domain/reservation/manage/action/ManageReservationsDropdown.js
+++ b/src/domain/reservation/manage/action/ManageReservationsDropdown.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import { isEmpty } from 'lodash';
 import { DropdownButton, MenuItem } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 
 import injectT from '../../../../../app/i18n/injectT';
 import { RESERVATION_STATE } from '../../../../constants/ReservationState';
+import { getApprovedState } from '../../utils';
 
 const UntranslatedManageReservationsDropdown = ({
   t, onInfoClick, reservation,
@@ -14,12 +14,8 @@ const UntranslatedManageReservationsDropdown = ({
   userCanCancel,
 }) => {
   const isRequestedReservation = reservation.state === RESERVATION_STATE.REQUESTED;
-  const isPaidReservationWithManualConfirmation = reservation.need_manual_confirmation
-    && !isEmpty(reservation.price_info);
+  const reservationApprovedState = getApprovedState(reservation);
 
-  const reservationConfirmationState = isPaidReservationWithManualConfirmation
-    ? RESERVATION_STATE.WAITING_FOR_PAYMENT
-    : RESERVATION_STATE.CONFIRMED;
   return (
     <div className="app-ManageReservationDropdown">
       {userCanModify && (
@@ -31,10 +27,16 @@ const UntranslatedManageReservationsDropdown = ({
             {t('ManageReservationsList.actionLabel.information')}
           </MenuItem>
 
+          {/*
+            TODO: This should be changed so that clicking 'Approve'/'Deny' would utilize
+            app.actions.reservationAction.confirmPreliminaryReservation and
+            app.actions.reservationAction.denyPreliminaryReservation, respectively,
+            instead of having duplicate code for handling approvals/denials in onEditReservation.
+          */}
           {isRequestedReservation && (
             <>
               <MenuItem
-                onClick={() => onEditReservation(reservation, reservationConfirmationState)}
+                onClick={() => onEditReservation(reservation, reservationApprovedState)}
               >
                 {t('ManageReservationsList.actionLabel.approve')}
               </MenuItem>

--- a/src/domain/reservation/modal/ReservationInformationModal.js
+++ b/src/domain/reservation/modal/ReservationInformationModal.js
@@ -12,7 +12,7 @@ import { getDateAndTime } from '../manage/list/ManageReservationsList';
 import { RESERVATION_STATE } from '../../../constants/ReservationState';
 import ReservationMetadata from '../information/ReservationMetadata';
 import ConnectedReservationCancelModal from './ReservationCancelModal';
-import { getShowRefundPolicy } from '../utils';
+import { getApprovedState, getShowRefundPolicy } from '../utils';
 import ReservationInformationModalContentRow from './ReservationInformationModalContentRow';
 
 const ReservationInformationModal = ({
@@ -53,6 +53,7 @@ const ReservationInformationModal = ({
   const payerLastName = get(reservation, 'billing_last_name', '');
   const payerEmail = get(reservation, 'billing_email_address', '');
   const isRequestedReservation = reservation.state === RESERVATION_STATE.REQUESTED;
+  const approvedState = getApprovedState(reservation);
   const showRefundPolicy = resource !== null && getShowRefundPolicy(isAdmin, reservation);
 
   const priceInfo = get(reservation, 'price_info', {});
@@ -163,7 +164,7 @@ const ReservationInformationModal = ({
 
             <Button
               bsStyle="success"
-              onClick={() => onEditReservation(normalizedReservation, RESERVATION_STATE.CONFIRMED)}
+              onClick={() => onEditReservation(normalizedReservation, approvedState)}
             >
               {t('ReservationInfoModal.approveButton')}
             </Button>

--- a/src/domain/reservation/utils.js
+++ b/src/domain/reservation/utils.js
@@ -3,6 +3,7 @@ import find from 'lodash/find';
 import sortBy from 'lodash/sortBy';
 import clone from 'lodash/clone';
 import tail from 'lodash/tail';
+import isEmpty from 'lodash/isEmpty';
 import last from 'lodash/last';
 import merge from 'lodash/merge';
 import get from 'lodash/get';
@@ -149,4 +150,14 @@ export const getShowRefundPolicy = (isAdmin, reservation) => {
   const price = getReservationPrice(reservation.begin, reservation.end, reservation.price_info);
 
   return isAdmin && !isStaffEvent && price > 0;
+};
+
+
+export const getApprovedState = (reservation) => {
+  const isPaidReservationWithManualConfirmation = reservation.need_manual_confirmation
+    && !isEmpty(reservation.price_info);
+
+  return isPaidReservationWithManualConfirmation
+    ? RESERVATION_STATE.WAITING_FOR_PAYMENT
+    : RESERVATION_STATE.CONFIRMED;
 };


### PR DESCRIPTION
Make sure the correct state and the payment return URL are sent when approving a reservation that requires payment. This includes:
- My reservations 'Approve' button
- Manage reservations: 'Approve' action in action dropdown
- Manage reservations: 'Approve' button in reservation modal

Previously only the 'Approve' dropdown action in Manage reservations was handled correctly.

Some code refactoring would still be needed to reduce code duplication regarding the approve/decline functionality.

Refs TTVA-100