### PR TITLE
Render None of the above event type option conditionally (TTVA-99)

### DIFF
--- a/app/pages/reservation/reservation-information/ReservationInformationForm.js
+++ b/app/pages/reservation/reservation-information/ReservationInformationForm.js
@@ -161,7 +161,12 @@ class UnconnectedReservationInformationForm extends Component {
 
     // Add "None of the above" as the last option. This option does not affect the price
     // but the user is still required to select it if none of the other options apply.
-    eventTypeOptions.push({ value: null, label: t('ReservationInformationForm.noneOfTheAboveOptionLabel') });
+    if (resource.includeOtherEventTypeOption) {
+      eventTypeOptions.push({
+        value: null,
+        label: t('ReservationInformationForm.noneOfTheAboveOptionLabel'),
+      });
+    }
 
     return eventTypeOptions;
   }

--- a/app/pages/reservation/reservation-information/__tests__/ReservationInformationForm.test.js
+++ b/app/pages/reservation/reservation-information/__tests__/ReservationInformationForm.test.js
@@ -285,6 +285,7 @@ describe('pages/reservation/reservation-information/ReservationInformationForm',
     describe('event type options', () => {
       test('includes none of the above option', () => {
         const resource = Resource.build({
+          includeOtherEventTypeOption: true,
           pricingEventTypes: [{
             id: 1,
             name: 'Event type 1',


### PR DESCRIPTION
Show the None of the above event type option in the reservation form only if it should be included, i.e. when `includeOtherEventTypeOption` is `true`.

Related API change: https://github.com/andersinno/respa/pull/122

Refs TTVA-99, TTVA-103