### PR TITLE
Show price as 'From X €' for resources with mixed price type (TTVA-106)

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -126,6 +126,7 @@
   "common.select": "Select",
   "common.pay": "Pay",
   "common.paymentTimeLimitNote": "Please note the reservation should be paid within 15 minutes, or it will be cancelled.",
+  "common.priceFrom": "From",
   "common.userNameLabel": "Account name",
   "common.userEmailLabel": "Account email",
   "common.language.en": "English",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -126,6 +126,7 @@
   "common.select": "Valitse",
   "common.pay": "Maksa",
   "common.paymentTimeLimitNote": "Huom! Varaus tulee maksaa 15 minuutin sisällä. Muuten varaus perutaan automaattisesti.",
+  "common.priceFrom": "Alk.",
   "common.userNameLabel": "Tilin nimi",
   "common.userEmailLabel": "Tilin sähköposti",
   "common.language.en": "English",

--- a/src/domain/resource/__tests__/utils.test.js
+++ b/src/domain/resource/__tests__/utils.test.js
@@ -196,6 +196,14 @@ describe('domain resource utility function', () => {
       }, fakeT);
       expect(price).toEqual('100 €');
     });
+
+    test('returns from min price if price type is mixed', () => {
+      const price = resourceUtils.getPriceFromSnakeCaseResource({
+        min_price: '100.00',
+        price_type: 'mixed',
+      }, fakeT);
+      expect(price).toEqual('common.priceFrom 100 €');
+    });
   });
 
   describe('isFree', () => {

--- a/src/domain/resource/constants.js
+++ b/src/domain/resource/constants.js
@@ -8,6 +8,7 @@ export const resourcePriceTypes = Object.freeze({
   DAILY: 'daily',
   WEEKLY: 'weekly',
   FIXED: 'fixed',
+  MIXED: 'mixed',
 });
 
 export const productPriceType = Object.freeze({

--- a/src/domain/resource/utils.js
+++ b/src/domain/resource/utils.js
@@ -87,6 +87,10 @@ export const getPrice = (minPriceString, maxPriceString, priceType, t, freeToUse
     return t('ResourceIcons.free');
   }
 
+  if (priceType === resourcePriceTypes.MIXED) {
+    return `${t('common.priceFrom')} ${Number(minPrice)} €`;
+  }
+
   const priceEnding = getPriceEnding(priceType, {
     hour: t('common.unit.time.hour'),
     day: t('common.unit.time.day'),


### PR DESCRIPTION
If the resource has prices that are neither fixed or hourly/daily/weekly, show the price as 'From X €', with X being the minimum price.

<img width="1401" alt="image" src="https://github.com/andersinno/varaamo/assets/5648062/456f9d46-bafd-45c9-879a-1cc633fd325d">


Refs TTVA-106