### PR TITLE
Reservations: fix staff comment field error

### DIFF
--- a/app/pages/reservation/reservation-information/InternalReservationFields.js
+++ b/app/pages/reservation/reservation-information/InternalReservationFields.js
@@ -128,7 +128,6 @@ class UnconnectedInternalReservationFields extends Component {
                 label="comments"
                 maxLength={commentsMaxLengths}
                 name="comments"
-                onChange={this.handleChangeReservationType}
                 rows={5}
               />
               {


### PR DESCRIPTION
https://andersinno.atlassian.net/browse/TTVA-76?focusedCommentId=10262

The comment field erroneously had this handler:

onChange={this.handleChangeReservationType}

This handler triggers the reservation type state that determines whether to show/hide payment fields. This handler should have been only on the checkbox options, not this field.

