### PR TITLE
Translations: update "Business ID" label

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -117,7 +117,7 @@
   "common.reserverAddressStreetLabel": "Street address",
   "common.reserverAddressZipLabel": "Postcode",
   "common.reserverEmailAddressLabel": "E-mail",
-  "common.reserverIdLabel": "Business ID / social security number",
+  "common.reserverIdLabel": "Business ID",
   "common.reserverNameLabel": "The person making the reservation / lessee",
   "common.reserverPhoneNumberLabel": "Phone",
   "common.resourceLabel": "Premises",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -117,7 +117,7 @@
   "common.reserverAddressStreetLabel": "Osoite",
   "common.reserverAddressZipLabel": "Postinumero",
   "common.reserverEmailAddressLabel": "Sähköposti",
-  "common.reserverIdLabel": "Y-tunnus / henkilötunnus",
+  "common.reserverIdLabel": "Y-tunnus",
   "common.reserverNameLabel": "Varaaja / vuokraaja",
   "common.reserverPhoneNumberLabel": "Puhelin",
   "common.resourceLabel": "Tila",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -117,7 +117,7 @@
   "common.reserverAddressStreetLabel": "Gatuadress",
   "common.reserverAddressZipLabel": "Postnummer",
   "common.reserverEmailAddressLabel": "E-post",
-  "common.reserverIdLabel": "FO-nummer/personbeteckning",
+  "common.reserverIdLabel": "FO-nummer",
   "common.reserverNameLabel": "Bokare/hyrestagare",
   "common.reserverPhoneNumberLabel": "Telefon",
   "common.resourceLabel": "Utrymme",


### PR DESCRIPTION
Finnish, Swedish and English translations updated to just show "Business ID".

https://andersinno.atlassian.net/jira/software/c/projects/TTVA/boards/11?modal=detail&selectedIssue=TTVA-128