### PR TITLE
Add Azure AD to the resource auth mapping (TTVA-104)

### DIFF
--- a/app/pages/resource/resource-auth-mapping.js
+++ b/app/pages/resource/resource-auth-mapping.js
@@ -22,17 +22,23 @@ export const RESOURCE_AUTHENTICATION_GROUPING = {
   'strong': {
     loginMethodNames: ['Suomi.fi'],
     loginMethodIcons: [suomiFiIcon],
-    canReserveWith: ['suomifi', 'tampere_adfs'],
+    canReserveWith: ['suomifi', 'tampere_adfs', 'tampereazuread'],
   },
   'PIKI': {
     loginMethodNames: ['PIKI-kirjastokortti'],
     loginMethodIcons: [pikiIcon],
-    canReserveWith: ['axiell_aurora', 'tampere_adfs'],
+    canReserveWith: ['axiell_aurora', 'tampere_adfs', 'tampereazuread'],
   },
   'mid': {
     loginMethodNames: ['Suomi.fi', 'Phone', 'PIKI-kirjastokortti'],
     loginMethodIcons: [suomiFiIcon, mobileIcon, pikiIcon],
-    canReserveWith: ['suomifi', 'mobile', 'axiell_aurora', 'tampere_adfs'],
+    canReserveWith: [
+      'suomifi',
+      'mobile',
+      'axiell_aurora',
+      'tampere_adfs',
+      'tampereazuread',
+    ],
   },
   'weak': {
     loginMethodNames: [
@@ -59,6 +65,7 @@ export const RESOURCE_AUTHENTICATION_GROUPING = {
       'facebook',
       'yletunnus',
       'tampere_adfs',
+      'tampereazuread',
     ],
   },
 };
@@ -70,4 +77,5 @@ export const LOGIN_METHODS_NAMES = {
   'google': 'Google',
   'facebook': 'Facebook',
   'yletunnus': 'Yletunnus',
+  'tampereazuread': 'Azure AD',
 };


### PR DESCRIPTION
Add Azure AD to the login method's (so the name of the login method is shown to the user when logged in) and also add it to the same resource authentication groups as ADFS.

![image](https://github.com/andersinno/varaamo/assets/5648062/92f5c978-3172-4c07-a138-de93a9ae1b29)


Refs TTVA-104