### PR TITLE
Remove the Phone auth method icons from Resource card (TTVA-160)

### DIFF
--- a/app/pages/resource/resource-auth-mapping.js
+++ b/app/pages/resource/resource-auth-mapping.js
@@ -1,6 +1,5 @@
 import facebookIcon from '../../assets/icons/facebook.svg';
 import googleIcon from '../../assets/icons/google.svg';
-import mobileIcon from '../../assets/icons/mobile.svg';
 import pikiIcon from '../../assets/icons/piki.png';
 import suomiFiIcon from '../../assets/icons/suomiFi.svg';
 import yleIcon from '../../assets/icons/yle.svg';
@@ -12,10 +11,10 @@ The order of loginMethodNames and loginMethodIcons should match since the title/
 icons is used from loginMethodNames.
 
 Users logged in with higher level of authentication can reserve resources that needs the
-same or lower level of authentication. E.g. User logged in with phone (mid strength
-auth) can reserve resources that have  mid/weak/none as authentication level. PIKI is
+same or lower level of authentication. E.g. User logged in with Suomi.fi (strong strength
+auth) can reserve resources that have strong/mid/weak/none as authentication level. PIKI is
 an exception here. The resource that needs piki authentication can only be reserved
-with PIKI login. Howerver, with PIKI login one can reserve resources with auth level
+with PIKI login. However, with PIKI login one can reserve resources with auth level
 of piki/mid/weak/none.
 */
 export const RESOURCE_AUTHENTICATION_GROUPING = {
@@ -30,11 +29,10 @@ export const RESOURCE_AUTHENTICATION_GROUPING = {
     canReserveWith: ['axiell_aurora', 'tampere_adfs', 'tampereazuread'],
   },
   'mid': {
-    loginMethodNames: ['Suomi.fi', 'Phone', 'PIKI-kirjastokortti'],
-    loginMethodIcons: [suomiFiIcon, mobileIcon, pikiIcon],
+    loginMethodNames: ['Suomi.fi', 'PIKI-kirjastokortti'],
+    loginMethodIcons: [suomiFiIcon, pikiIcon],
     canReserveWith: [
       'suomifi',
-      'mobile',
       'axiell_aurora',
       'tampere_adfs',
       'tampereazuread',
@@ -44,7 +42,6 @@ export const RESOURCE_AUTHENTICATION_GROUPING = {
     loginMethodNames: [
       'Suomi.fi',
       'PIKI-kirjastokortti',
-      'Phone',
       'Google',
       'Facebook',
       'Yle Tunnus',
@@ -52,7 +49,6 @@ export const RESOURCE_AUTHENTICATION_GROUPING = {
     loginMethodIcons: [
       suomiFiIcon,
       pikiIcon,
-      mobileIcon,
       googleIcon,
       facebookIcon,
       yleIcon,
@@ -60,7 +56,6 @@ export const RESOURCE_AUTHENTICATION_GROUPING = {
     canReserveWith: [
       'suomifi',
       'axiell_aurora',
-      'mobile',
       'google',
       'facebook',
       'yletunnus',

--- a/src/domain/resource/__tests__/utils.test.js
+++ b/src/domain/resource/__tests__/utils.test.js
@@ -591,13 +591,13 @@ describe('domain resource utility function', () => {
 
     test('are rendered correctly for mid auth', () => {
       const resource = { authentication: 'mid' };
-      const allowedLoginMethodNamesString = 'Suomi.fi/Phone/PIKI-kirjastokortti';
+      const allowedLoginMethodNamesString = 'Suomi.fi/PIKI-kirjastokortti';
       expect(resourceUtils.getRequiredLoginMethod(resource)).toEqual(allowedLoginMethodNamesString);
     });
 
     test('are rendered correctly for weak auth', () => {
       const resource = { authentication: 'weak' };
-      const allowedLoginMethodNamesString = 'Suomi.fi/PIKI-kirjastokortti/Phone/Google/Facebook/Yle Tunnus';
+      const allowedLoginMethodNamesString = 'Suomi.fi/PIKI-kirjastokortti/Google/Facebook/Yle Tunnus';
       expect(resourceUtils.getRequiredLoginMethod(resource)).toEqual(allowedLoginMethodNamesString);
     });
 

--- a/src/domain/resource/card/__tests__/__snapshots__/ResourceCard.test.js.snap
+++ b/src/domain/resource/card/__tests__/__snapshots__/ResourceCard.test.js.snap
@@ -127,13 +127,6 @@ exports[`ResourceCard renders correctly 1`] = `
           title="PIKI-kirjastokortti"
         />
         <img
-          alt="Phone"
-          className="app-resourceCardInfoCell__icon"
-          key="Phone"
-          src="test-file-stub"
-          title="Phone"
-        />
-        <img
           alt="Google"
           className="app-resourceCardInfoCell__icon"
           key="Google"


### PR DESCRIPTION
Remove the Phone authentication level icons from the resource search and details views. Mobile authentication is not in use at all so these icons are unnecessary.

![image](https://github.com/andersinno/varaamo/assets/5648062/7beaae39-d1ae-46b1-bd54-1b1c65450f80)


Refs TTVA-160