### PR TITLE
Hide recurring event option for personal use staff reservations (TTVA-163)

### DIFF
--- a/app/pages/reservation/ReservationPage.js
+++ b/app/pages/reservation/ReservationPage.js
@@ -191,6 +191,9 @@ class UnconnectedReservationPage extends Component {
 
   handleChangeReservationType(reservationType) {
     this.setState({ reservationType });
+    if (reservationType === RESERVATION_TYPE.NORMAL) {
+      this.props.actions.changeFrequency('');
+    }
   }
 
   handleChangeInvoiceRequested(isInvoiceRequested) {
@@ -327,6 +330,7 @@ class UnconnectedReservationPage extends Component {
 
     const isPaymentRequired = this.isPaymentRequired();
     const isPayableAmount = this.isPayableAmount();
+    const showOccuranceControls = isAdmin && this.state.reservationType !== RESERVATION_TYPE.NORMAL;
 
     const setReservationPriceInfo = (info) => {
       this.setState({ reservationPriceInfo: info });
@@ -362,7 +366,7 @@ class UnconnectedReservationPage extends Component {
                 )}
                 {view === 'information' && selectedTime && (
                   <>
-                    {isAdmin && this.renderRecurringReservations()}
+                    {showOccuranceControls && this.renderRecurringReservations()}
                     <ReservationInformation
                       isAdmin={isAdmin}
                       isEditing={isEditing}
@@ -441,6 +445,7 @@ function mapDispatchToProps(dispatch) {
     putReservation,
     postReservation,
     removeReservation: recurringReservationsConnector.removeReservation,
+    changeFrequency: recurringReservationsConnector.changeFrequency,
     setSelectedTimeSlots,
     addNotification,
   };

--- a/app/pages/reservation/__tests__/ReservationPage.test.js
+++ b/app/pages/reservation/__tests__/ReservationPage.test.js
@@ -26,6 +26,7 @@ describe('pages/reservation/ReservationPage', () => {
     history,
     actions: {
       clearReservations: simple.mock(),
+      changeFrequency: jest.fn(),
       closeReservationSuccessModal: simple.mock(),
       fetchResource: simple.mock(),
       openResourceTermsModal: simple.mock(),
@@ -173,6 +174,14 @@ describe('pages/reservation/ReservationPage', () => {
       expect(controls).toHaveLength(0);
     });
 
+    test('does not render RecurringReservationControls component for admins if reservation type is normal', () => {
+      defaultProps.isStaff = true;
+      const wrapper = getWrapper({ isAdmin: true });
+      wrapper.setState({ reservationType: 'normal' });
+      const controls = wrapper.find(RecurringReservationControls);
+      expect(controls).toHaveLength(0);
+    });
+
     test('does not render CompactReservationList if user is not admin', () => {
       defaultProps.isStaff = false; // RecurringReservation visibility is based on isStaff value!
       const list = getWrapper({ isAdmin: false }).find(CompactReservationList);
@@ -313,6 +322,23 @@ describe('pages/reservation/ReservationPage', () => {
       const instance = getWrapper({}).instance();
       instance.handleChangeReservationType('normal');
       expect(instance.state.reservationType).toBe('normal');
+    });
+
+    test('clears occurances when reservation type is set to normal', () => {
+      const occurances = [
+        {
+          begin: '2023-06-18T15:00:00.000Z',
+          end: '2023-06-18T16:00:00.000Z',
+        },
+        {
+          begin: '2023-07-18T15:00:00.000Z',
+          end: '2023-07-18T16:00:00.000Z',
+        },
+      ];
+      const instance = getWrapper({ recurringReservations: occurances }).instance();
+      expect(instance.props.recurringReservations).toEqual(occurances);
+      instance.handleChangeReservationType('normal');
+      expect(defaultProps.actions.changeFrequency).toHaveBeenCalledWith('');
     });
   });
 


### PR DESCRIPTION
For staff users, if the selected reservation type is 'For personal use', do not allow creating a reoccurring reservation. Also make sure the occurances are cleared if the user first sets an occurance and then changes the reservation type.

![image](https://github.com/andersinno/varaamo/assets/5648062/0634e120-d8f4-45eb-8caa-939503ecc79f)

Refs TTVA-163