### PR TITLE
Calendar: reservable before date should not include the last date

### DIFF
--- a/src/common/form/fields/__tests__/__snapshots__/DateField.test.js.snap
+++ b/src/common/form/fields/__tests__/__snapshots__/DateField.test.js.snap
@@ -65,20 +65,22 @@ exports[`DateField renders correctly 1`] = `
           "_callbacks": Array [],
           "_renderer": ReactShallowRenderer {
             "_context": Object {},
-            "_currentlyRenderingComponent": null,
             "_didScheduleRenderPhaseUpdate": false,
             "_dispatcher": Object {
               "readContext": [Function],
               "useCallback": [Function],
               "useContext": [Function],
               "useDebugValue": [Function],
+              "useDeferredValue": [Function],
               "useEffect": [Function],
               "useImperativeHandle": [Function],
               "useLayoutEffect": [Function],
               "useMemo": [Function],
               "useReducer": [Function],
               "useRef": [Function],
+              "useResponder": [Function],
               "useState": [Function],
+              "useTransition": [Function],
             },
             "_element": <UntranslatedDateField
               id="foo"
@@ -93,7 +95,6 @@ exports[`DateField renders correctly 1`] = `
             "_isReRender": false,
             "_newState": null,
             "_numberOfReRenders": 0,
-            "_previousComponentIdentity": null,
             "_renderPhaseUpdates": null,
             "_rendered": <div
               className="app-DateField"

--- a/src/domain/resource/utils.js
+++ b/src/domain/resource/utils.js
@@ -407,7 +407,8 @@ export const isDateReservable = (resource, date) => {
   const reservableBefore = get(resource, 'reservable_before', null);
 
   const isAdmin = get(resource, 'user_permissions.is_admin', false);
-  const isBefore = reservableBefore ? moment(date).isSameOrBefore(moment(reservableBefore), 'day') : true;
+  // reservableBefore is up to midnight of that day, so we should only count before that day.
+  const isBefore = reservableBefore ? moment(date).isBefore(moment(reservableBefore), 'day') : true;
   const isAfter = reservableAfter ? moment(date).isSameOrAfter(moment(reservableAfter), 'day') : true;
 
   return isAdmin || (isBefore && isAfter);

--- a/src/domain/search/filters/filter/__tests__/__snapshots__/DateFilter.test.js.snap
+++ b/src/domain/search/filters/filter/__tests__/__snapshots__/DateFilter.test.js.snap
@@ -93,20 +93,22 @@ exports[`DateFilter render normally 1`] = `
           "_callbacks": Array [],
           "_renderer": ReactShallowRenderer {
             "_context": Object {},
-            "_currentlyRenderingComponent": null,
             "_didScheduleRenderPhaseUpdate": false,
             "_dispatcher": Object {
               "readContext": [Function],
               "useCallback": [Function],
               "useContext": [Function],
               "useDebugValue": [Function],
+              "useDeferredValue": [Function],
               "useEffect": [Function],
               "useImperativeHandle": [Function],
               "useLayoutEffect": [Function],
               "useMemo": [Function],
               "useReducer": [Function],
               "useRef": [Function],
+              "useResponder": [Function],
               "useState": [Function],
+              "useTransition": [Function],
             },
             "_element": <UntranslatedDateFilter
               date={2017-12-09T22:00:00.000Z}
@@ -136,7 +138,6 @@ exports[`DateFilter render normally 1`] = `
             "_isReRender": false,
             "_newState": null,
             "_numberOfReRenders": 0,
-            "_previousComponentIdentity": null,
             "_renderPhaseUpdates": null,
             "_rendered": <div
               className="app-DateFilter"


### PR DESCRIPTION
Resource.reservableBefore is always to midnight of that day, e.g. 13 Oct 0:00. The calendar counts the whole of the 13th, rather than up to but
  not including that date.

![Screenshot from 2023-10-05 17-38-36](https://github.com/andersinno/varaamo/assets/131681805/71addcf6-0196-4c55-80ca-8275efee9b61)

