### PR TITLE
Hotfix: ensure we do not count last day in reservableBefore calculation

### DIFF
--- a/src/domain/resource/utils.js
+++ b/src/domain/resource/utils.js
@@ -407,7 +407,7 @@ export const isDateReservable = (resource, date) => {
   const reservableBefore = get(resource, 'reservable_before', null);
 
   const isAdmin = get(resource, 'user_permissions.is_admin', false);
-  const isBefore = reservableBefore ? moment(date).isSameOrBefore(moment(reservableBefore), 'day') : true;
+  const isBefore = reservableBefore ? moment(date).isBefore(moment(reservableBefore), 'day') : true;
   const isAfter = reservableAfter ? moment(date).isSameOrAfter(moment(reservableAfter), 'day') : true;
 
   return isAdmin || (isBefore && isAfter);


### PR DESCRIPTION
The Resource.reservableBefore property is calculated to midnight of the last day e.g. before 13 Oct 0.00.

The calendar however counts that day for the purposes of it being available for the whole day. We should therefore only include dates *before* reservableBefore.

![Screenshot from 2023-10-05 17-38-36](https://github.com/andersinno/varaamo/assets/131681805/3c861abb-2066-4f50-bad2-899079fb8e39)
