### PR TITLE
Add missing reservation status label (TTVA-178)

### DIFF
--- a/app/constants/AppConstants.js
+++ b/app/constants/AppConstants.js
@@ -58,6 +58,10 @@ export default {
       labelBsStyle: 'success',
       labelTextId: 'common.confirmed',
     },
+    invoice_requested: {
+      labelBsStyle: 'primary',
+      labelTextId: 'common.requested',
+    },
     paid: {
       labelBsStyle: 'success',
       labelTextId: 'common.confirmed',
@@ -95,6 +99,14 @@ export default {
     cancelled: {
       labelBsStyle: 'danger',
       labelTextId: 'payment.cancelled',
+    },
+    invoice_requested: {
+      labelBsStyle: 'primary',
+      labelTextId: 'common.requested',
+    },
+    in_invoicing: {
+      labelBsStyle: 'success',
+      labelTextId: 'payment.inInvoicing',
     },
   },
   SEARCH_PAGE_SIZE: 30,

--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -71,6 +71,7 @@
   "payment.paid": "Paid",
   "payment.success": "Payment successful",
   "payment.processing": "Processing payment",
+  "payment.inInvoicing": "In Invoicing",
   "payment.failed": "Payment failed",
   "payment.cancelled": "Payment cancelled",
   "payment.waiting": "Waiting for payment",

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -71,6 +71,7 @@
   "payment.paid": "Maksettu",
   "payment.success": "Maksu suoritettu",
   "payment.processing": "Käsitellään maksua",
+  "payment.inInvoicing": "Laskutuksessa",
   "payment.failed": "Maksu epäonnistui",
   "payment.cancelled": "Maksu keskeytetty",
   "payment.waiting": "Odottaa maksua",

--- a/app/i18n/messages/sv.json
+++ b/app/i18n/messages/sv.json
@@ -64,6 +64,7 @@
   "payment.paid": "Betald",
   "payment.success": "Betalning genomförd",
   "payment.processing": "Behandlar betalning",
+  "payment.inInvoicing": "Vid Fakturering",
   "payment.failed": "Betalning misslyckades",
   "payment.cancelled": "Betalning avbruten",
   "payment.waiting": "Väntar på utbetalning",

--- a/app/pages/user-reservations/reservation-filters/__tests__/AdminReservationFilters.test.js
+++ b/app/pages/user-reservations/reservation-filters/__tests__/AdminReservationFilters.test.js
@@ -35,6 +35,7 @@ describe('pages/user-reservations/reservation-filters/AdminReservationFilters', 
         { label: 'common.confirmed', value: 'paid' },
         { label: 'common.denied', value: 'denied' },
         { label: 'common.requested', value: 'requested' },
+        { label: 'common.requested', value: 'invoice_requested' },
         { label: 'common.waiting', value: 'waiting_for_payment' },
       ];
       expect(select.props().options).toEqual(expected);

--- a/app/pages/user-reservations/reservation-list/ReservationListItem.js
+++ b/app/pages/user-reservations/reservation-list/ReservationListItem.js
@@ -49,7 +49,8 @@ class ReservationListItem extends Component {
 
     const nameSeparator = isEmpty(resource) || isEmpty(unit) ? '' : ', ';
 
-    const paymentLabel = constants.RESERVATION_PAYMENT_LABELS[reservation.state];
+    const confirmedAndInvoiceable = reservation.state === 'confirmed' && reservation.invoice_requested;
+    const paymentLabel = constants.RESERVATION_PAYMENT_LABELS[confirmedAndInvoiceable ? 'in_invoicing' : reservation.state];
     const statusLabel = constants.RESERVATION_STATE_LABELS[reservation.state];
     let price;
     let vat;


### PR DESCRIPTION
- If the reservation status is `invoice_requested`, show "Requested" as the general status label. The "My Reservations" page failed to render because of this.

- If the reservation is confirmed but will be invoiced, instead of showing "Payment successful" as the payment status, show "In Invoicing".

![image](https://github.com/andersinno/varaamo/assets/5648062/7c392abb-1779-4659-91b3-83c9f048636d)
