### PR TITLE
Invoicing: Make company field required in reservation form (TTVA-179)

### DIFF
--- a/app/pages/reservation/reservation-information/ReservationInformation.js
+++ b/app/pages/reservation/reservation-information/ReservationInformation.js
@@ -164,6 +164,7 @@ class ReservationInformation extends Component {
 
     const invoiceFields = [
       'reserverId',
+      'company',
       'companyAddressZip',
       'companyAddressCity',
       'companyAddressStreet',

--- a/app/pages/reservation/reservation-information/__tests__/ReservationInformation.test.js
+++ b/app/pages/reservation/reservation-information/__tests__/ReservationInformation.test.js
@@ -405,6 +405,7 @@ describe('pages/reservation/reservation-information/ReservationInformation', () 
 
     const invoiceFields = [
       'reserverId',
+      'company',
       'companyAddressZip',
       'companyAddressCity',
       'companyAddressStreet',


### PR DESCRIPTION
Make the company field in the reservation form required when invoicing is selected as the payment method. The company name is required in the invoicing data that is sent to SAP.

See the related PR for Respa: https://github.com/andersinno/respa/pull/168

Refs TTVA-179