### PR TITLE
Add user email address form modal (STAM-5)

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -516,5 +516,14 @@
   "CalendarLegend.closed": "Unavailable",
   "CalendarLegend.selection": "My reservation",
   "CalendarLegend.taken": "Taken",
-  "CalendarLegend.available": "Available"
+  "CalendarLegend.available": "Available",
+  "UserEmailForm.title": "Email address required",
+  "UserEmailForm.text": "In order to send reservation related emails from Varaamo, we need your email address.",
+  "UserEmailForm.text2": "Please provide your email address so that we can save it to your user details.",
+  "UserEmailForm.emailFieldLabel": "Email address",
+  "UserEmailForm.emailField2Label": "Confirm email address",
+  "UserEmailForm.confirmButton": "Confirm",
+  "UserEmailForm.emailMismatchError": "The email addresses do not match.",
+  "UserEmailForm.emailSet": "Email address saved.",
+  "UserEmailForm.failedToSetEmail": "Failed to save the email address. Either the format is incorrect or the email address is already in use."
 }

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -526,5 +526,14 @@
   "CalendarLegend.closed": "Ei varattavissa",
   "CalendarLegend.selection": "Oma varaus",
   "CalendarLegend.taken": "Varattu",
-  "CalendarLegend.available": "Vapaa"
+  "CalendarLegend.available": "Vapaa",
+  "UserEmailForm.title": "Sähköpostiosoite tarvitaan",
+  "UserEmailForm.text": "Jotta Varaamosta voidaan lähettää varauksiin liittyviä sähköposteja, tarvitsemme sähköpostiosoitteesi.",
+  "UserEmailForm.text2": "Annathan sähköpostiosoitteesi, jotta se voidaan tallentaa tietoihisi.",
+  "UserEmailForm.emailFieldLabel": "Sähköpostiosoite",
+  "UserEmailForm.emailField2Label": "Sähköpostiosoite uudelleen",
+  "UserEmailForm.confirmButton": "Vahvista",
+  "UserEmailForm.emailMismatchError": "Sähköpostiosoitteet eivät vastaa toisiaan.",
+  "UserEmailForm.emailSet": "Sähköpostiosoite tallennettu.",
+  "UserEmailForm.failedToSetEmail": "Sähköpostiosoitteen tallennus epäonnistui. Joko sähköpostiosoitteen muoto ei kelpaa tai se on jo käytössä."
 }

--- a/app/pages/AppContainer.js
+++ b/app/pages/AppContainer.js
@@ -10,7 +10,7 @@ import { withRouter } from 'react-router-dom';
 import { NotificationContainer } from 'react-notifications';
 import firebase from 'firebase/app';
 
-import { isAdminSelector } from '../state/selectors/authSelectors';
+import { isAdminSelector, currentUserSelector } from '../state/selectors/authSelectors';
 import { fetchUser } from '../actions/userActions';
 import { enableGeoposition } from '../actions/uiActions';
 import Favicon from '../shared/favicon/Favicon';
@@ -21,6 +21,7 @@ import { getCustomizationClassName } from '../utils/customizationUtils';
 import Notifications from '../shared/notifications/NotificationsContainer';
 import UserNotificator from '../../src/common/notificator/user/UserNotificator';
 import AccessibilityShortcuts from '../shared/accessibility-shortcuts/AccessibilityShortcuts';
+import UserEmailFormModal from '../shared/modals/user-email-form/UserEmailFormModal';
 import FontSizes from '../constants/FontSizes';
 
 const userIdSelector = state => state.auth.userId;
@@ -34,6 +35,7 @@ export const selector = createStructuredSelector({
   userId: userIdSelector,
   fontSize: fontSizeSelector,
   isHighContrast: isHighContrastSelector,
+  user: currentUserSelector,
 });
 
 export class UnconnectedAppContainer extends Component {
@@ -67,9 +69,10 @@ export class UnconnectedAppContainer extends Component {
 
   render() {
     const {
-      isStaff, language, fontSize, isHighContrast,
+      isStaff, language, fontSize, isHighContrast, user, userId,
     } = this.props;
     const mainContentId = 'main-content';
+    const userHasEmail = Boolean(user && (user.email || user.emails));
 
     return (
       <>
@@ -101,6 +104,12 @@ export class UnconnectedAppContainer extends Component {
             {this.props.children}
           </div>
           <Footer />
+          {(userId) && (
+            <UserEmailFormModal
+              show={userId && !userHasEmail}
+              userId={userId}
+            />
+          )}
         </div>
       </>
     );
@@ -116,6 +125,7 @@ UnconnectedAppContainer.propTypes = {
   fetchUser: PropTypes.func.isRequired,
   location: PropTypes.object.isRequired,
   userId: PropTypes.string,
+  user: PropTypes.object,
   fontSize: PropTypes.oneOf(Object.values(FontSizes)),
 };
 

--- a/app/shared/modals/user-email-form/UserEmailFormModal.js
+++ b/app/shared/modals/user-email-form/UserEmailFormModal.js
@@ -1,0 +1,129 @@
+import React, { useState, useEffect } from 'react';
+import ControlLabel from 'react-bootstrap/lib/ControlLabel';
+import Form from 'react-bootstrap/lib/Form';
+import FormControl from 'react-bootstrap/lib/FormControl';
+import FormGroup from 'react-bootstrap/lib/FormGroup';
+import PropTypes from 'prop-types';
+import Modal from 'react-bootstrap/lib/Modal';
+import Button from 'react-bootstrap/lib/Button';
+
+import { createNotification } from '../../../../src/common/notification/utils';
+import { NOTIFICATION_TYPE } from '../../../../src/common/notification/constants';
+import client from '../../../../src/common/api/client';
+import injectT from '../../../i18n/injectT';
+
+function UserEmailFormModal({ userId, show, t }) {
+  const [open, setOpen] = useState(false);
+  const [error, setError] = useState(false);
+  const [emailMismatch, setEmailMismatch] = useState(false);
+  const [formData, setFormData] = useState({
+    email: '',
+    confirmEmail: '',
+  });
+
+  useEffect(() => {
+    setOpen(show);
+  }, [show]);
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    setEmailMismatch(false);
+    setError(false);
+
+    if (formData.email && formData.email === formData.confirmEmail) {
+      client.post(`user/${userId}/set_email`, { email: formData.email })
+        .then(() => {
+          createNotification(NOTIFICATION_TYPE.SUCCESS, t('UserEmailForm.emailSet'));
+          setOpen(false);
+        })
+        .catch((e) => {
+          setError(true);
+          createNotification(NOTIFICATION_TYPE.ERROR, t('UserEmailForm.failedToSetEmail'));
+        });
+    } else {
+      setEmailMismatch(true);
+    }
+  };
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setFormData(prevState => ({
+      ...prevState,
+      [name]: value,
+    }));
+  };
+
+  return (
+    <Modal
+      backdrop="static"
+      className="app-UserEmailFormModal"
+      keyboard={false}
+      show={open}
+    >
+      <Modal.Header>
+        <Modal.Title>
+          {t('UserEmailForm.title')}
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <p>{t('UserEmailForm.text')}</p>
+        <p>{t('UserEmailForm.text2')}</p>
+        <br />
+        <Form id="user-email-form" onSubmit={handleSubmit}>
+          <FormGroup controlId="textField-email">
+            <ControlLabel className="app-TextField__label">
+              {t('UserEmailForm.emailFieldLabel')}
+            </ControlLabel>
+            <FormControl
+              autoFocus
+              className="app-TextField__input"
+              name="email"
+              onChange={handleChange}
+              required
+              type="email"
+              value={formData.email}
+            />
+            <FormControl.Feedback />
+          </FormGroup>
+          <FormGroup controlId="textField-confirmEmail">
+            <ControlLabel className="app-TextField__label">
+              {t('UserEmailForm.emailField2Label')}
+            </ControlLabel>
+            <FormControl
+              className="app-TextField__input"
+              name="confirmEmail"
+              onChange={handleChange}
+              required
+              type="email"
+              value={formData.confirmEmail}
+            />
+            <FormControl.Feedback />
+          </FormGroup>
+        </Form>
+        {emailMismatch && (
+          <p className="emailMismatchErrorMessage">
+            {t('UserEmailForm.emailMismatchError')}
+          </p>
+        )}
+        {error && (
+          <p className="errorMessage">
+            {t('UserEmailForm.failedToSetEmail')}
+          </p>
+        )}
+      </Modal.Body>
+      <Modal.Footer>
+        <Button form="user-email-form" type="submit" variant="primary">
+          {t('UserEmailForm.confirmButton')}
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}
+
+UserEmailFormModal.propTypes = {
+  userId: PropTypes.string.isRequired,
+  show: PropTypes.bool.isRequired,
+  t: PropTypes.func.isRequired,
+};
+
+export default injectT(UserEmailFormModal);

--- a/app/shared/modals/user-email-form/__tests__/UserEmailFormModal.test.js
+++ b/app/shared/modals/user-email-form/__tests__/UserEmailFormModal.test.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import Button from 'react-bootstrap/lib/Button';
+import Modal from 'react-bootstrap/lib/Modal';
+
+import client from '../../../../../src/common/api/client';
+import { mountWithIntl } from '../../../../utils/testUtils';
+import UserEmailFormModal from '../UserEmailFormModal';
+
+jest.mock('../../../../../src/common/api/client', () => ({
+  post: jest.fn(() => Promise.resolve()),
+}));
+
+describe('UserEmailFormModal', () => {
+  const defaultProps = {
+    userId: '123',
+    show: true,
+  };
+
+  const setup = (props = {}) => {
+    const setupProps = { ...defaultProps, ...props };
+    return mountWithIntl(<UserEmailFormModal {...setupProps} />);
+  };
+
+  it('renders the component', () => {
+    const wrapper = setup();
+    const modalTitle = wrapper.find(Modal.Title);
+    const confirmButton = wrapper.find(Button);
+
+    expect(wrapper.find('Modal').exists()).toBe(true);
+    expect(modalTitle.prop('children')).toBe('UserEmailForm.title');
+    expect(wrapper.find('p').at(0).text()).toBe('UserEmailForm.text');
+    expect(wrapper.find('p').at(1).text()).toBe('UserEmailForm.text2');
+    expect(confirmButton.length).toBe(1);
+  });
+
+  it('submits the form successfully', async () => {
+    const wrapper = setup();
+    const emailInput = wrapper.find('FormControl[name="email"]').first();
+    const confirmEmailInput = wrapper.find('FormControl[name="confirmEmail"]').first();
+
+    // Set the values and trigger onChange handlers
+    act(() => {
+      emailInput.props().onChange({ target: { name: 'email', value: 'test@example.com' } });
+      confirmEmailInput.props().onChange({ target: { name: 'confirmEmail', value: 'test@example.com' } });
+    });
+
+    // Ensure component re-renders after state update
+    wrapper.update();
+
+    expect(wrapper.find('FormControl[name="email"]').prop('value')).toBe('test@example.com');
+    expect(wrapper.find('FormControl[name="confirmEmail"]').prop('value')).toBe('test@example.com');
+
+    // Simulate form submission and assert the API call
+    wrapper.find('Form').simulate('submit', { preventDefault: () => {} });
+    expect(client.post).toHaveBeenCalledWith('user/123/set_email', { email: 'test@example.com' });
+  });
+
+  it('handles email mismatch error', () => {
+    const wrapper = setup();
+
+    // Set the values and trigger onChange handlers
+    act(() => {
+      wrapper.find('FormControl[name="email"]').simulate('change', { target: { name: 'email', value: 'test@example.com' } });
+      wrapper.find('FormControl[name="confirmEmail"]').simulate('change', { target: { name: 'confirmEmail', value: 'mismatch@example.com' } });
+    });
+
+    // Ensure component re-renders after state update
+    wrapper.update();
+
+    expect(wrapper.find('FormControl[name="email"]').prop('value')).toBe('test@example.com');
+    expect(wrapper.find('FormControl[name="confirmEmail"]').prop('value')).toBe('mismatch@example.com');
+
+    // Simulate form submission and assert the API call
+    wrapper.find('Form').simulate('submit', { preventDefault: () => {} });
+    expect(wrapper.find('.emailMismatchErrorMessage').exists()).toBe(true);
+  });
+});


### PR DESCRIPTION
**Note: This depends on the backend PR to be merged first: https://github.com/andersinno/respa/pull/177**

If the user doesn't have an email address set in Respa, i.e. when they use an authentication backend that doesn't provide an email address (such as PIKI library card or Suomi.fi), show a modal with a form for setting the email address in Respa.

![image](https://github.com/andersinno/varaamo/assets/5648062/c7df1498-5713-4917-a8f0-a70e01177002)


Refs STAM-5