### PR TITLE
STAM-18 | Link breaks in contact person info

### DIFF
--- a/app/pages/resource/resource-info/ResourceInfo.js
+++ b/app/pages/resource/resource-info/ResourceInfo.js
@@ -98,7 +98,7 @@ function ResourceInfo({
         <ResourcePanel header={t('ResourceInfo.responsibleContactInfoTitle')}>
           <Row>
             <Col className="app-ResourceInfo__responsibleContactInfo" xs={6}>
-              {resource.responsibleContactInfo}
+              <WrappedText text={resource.responsibleContactInfo} />
             </Col>
           </Row>
         </ResourcePanel>


### PR DESCRIPTION
## Description
Display line breaks in contact person info text in resource info page

## Closes
[STAM-18](https://andersinno.atlassian.net/browse/STAM-18)

## Screenshot
<img width="976" alt="Näyttökuva 2024-09-27 kello 11 18 24" src="https://github.com/user-attachments/assets/c80bc692-d0a7-4e3a-be2b-e4dd610bbf3f">


