### PR TITLE
Add cancel button to email confirmation pop-up (TTVA-215)

### DIFF
--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -523,6 +523,7 @@
   "UserEmailForm.emailFieldLabel": "Email address",
   "UserEmailForm.emailField2Label": "Confirm email address",
   "UserEmailForm.confirmButton": "Confirm",
+  "UserEmailForm.cancelButton": "Cancel and return to login",
   "UserEmailForm.emailMismatchError": "The email addresses do not match.",
   "UserEmailForm.emailSet": "Email address saved.",
   "UserEmailForm.failedToSetEmail": "Failed to save the email address. Either the format is incorrect or the email address is already in use."

--- a/app/i18n/messages/fi.json
+++ b/app/i18n/messages/fi.json
@@ -533,6 +533,7 @@
   "UserEmailForm.emailFieldLabel": "Sähköpostiosoite",
   "UserEmailForm.emailField2Label": "Sähköpostiosoite uudelleen",
   "UserEmailForm.confirmButton": "Vahvista",
+  "UserEmailForm.cancelButton": "Peruuta ja palaa kirjautumissivulle",
   "UserEmailForm.emailMismatchError": "Sähköpostiosoitteet eivät vastaa toisiaan.",
   "UserEmailForm.emailSet": "Sähköpostiosoite tallennettu.",
   "UserEmailForm.failedToSetEmail": "Sähköpostiosoitteen tallennus epäonnistui. Joko sähköpostiosoitteen muoto ei kelpaa tai se on jo käytössä."

--- a/app/shared/modals/user-email-form/UserEmailFormModal.js
+++ b/app/shared/modals/user-email-form/UserEmailFormModal.js
@@ -112,7 +112,15 @@ function UserEmailFormModal({ userId, show, t }) {
         )}
       </Modal.Body>
       <Modal.Footer>
-        <Button form="user-email-form" type="submit" variant="primary">
+        <Button
+          form="user-email-form"
+          href={`/logout?next=${window.location.origin}/login`}
+          type="button"
+          variant="primary"
+        >
+          {t('UserEmailForm.cancelButton')}
+        </Button>
+        <Button bsStyle="primary" form="user-email-form" type="submit" variant="primary">
           {t('UserEmailForm.confirmButton')}
         </Button>
       </Modal.Footer>

--- a/app/shared/modals/user-email-form/__tests__/UserEmailFormModal.test.js
+++ b/app/shared/modals/user-email-form/__tests__/UserEmailFormModal.test.js
@@ -31,7 +31,7 @@ describe('UserEmailFormModal', () => {
     expect(modalTitle.prop('children')).toBe('UserEmailForm.title');
     expect(wrapper.find('p').at(0).text()).toBe('UserEmailForm.text');
     expect(wrapper.find('p').at(1).text()).toBe('UserEmailForm.text2');
-    expect(confirmButton.length).toBe(1);
+    expect(confirmButton.length).toBe(2);
   });
 
   it('submits the form successfully', async () => {


### PR DESCRIPTION
When the user logs in and doesn't have an email address saved to the user profile in Respa, a pop-up form is shown so the user can save an email address to their profile. Add a cancel button to the pop-up. When clicked, log the user out. Tunnistamo should then redirect the user back to the login page.

![Screenshot 2024-11-12 at 14 23 39](https://github.com/user-attachments/assets/2ca77f2b-58ae-4683-af4e-31623d119e2f)


Refs TTVA-215