### PR TITLE
TTVA-217 | Display people capacity range

### DIFF
--- a/app/pages/resource/resource-header/ResourceHeader.js
+++ b/app/pages/resource/resource-header/ResourceHeader.js
@@ -88,8 +88,9 @@ function ResourceHeader({
     }
     return undefined;
   };
-
-  const peopleCapacityText = t('ResourceCard.peopleCapacity', { people: resource.peopleCapacity });
+  const peopleCapacityText = t('ResourceCard.peopleCapacity', {
+    people: `${resource.peopleCapacityLower}${resource.peopleCapacityUpper ? `-${resource.peopleCapacityUpper}` : ''}`,
+  });
   const maxPeriodText = getMaxPeriodText(t, resource);
   const priceText = getPrice(t, resource);
   const typeName = resource.type ? resource.type.name : '\u00A0';

--- a/app/shared/resource-card/ResourceCard.js
+++ b/app/shared/resource-card/ResourceCard.js
@@ -126,7 +126,7 @@ class ResourceCard extends Component {
             onClick={this.handleSearchByPeopleCapacity}
           >
             <span className="app-ResourceCard__peopleCapacity">
-              {t('ResourceCard.peopleCapacity', { people: resource.peopleCapacity })}
+              {t('ResourceCard.peopleCapacity', { people: `${resource.peopleCapacityLower}${resource.peopleCapacityUpper ? `-${resource.peopleCapacityUpper}` : ''}` })}
             </span>
           </ResourceCardInfoCell>
 

--- a/src/domain/resource/card/ResourceCard.js
+++ b/src/domain/resource/card/ResourceCard.js
@@ -236,7 +236,7 @@ render() {
           text={
               resource.people_capacity
                 ? t('ResourceCard.peopleCapacity', {
-                  people: resource.people_capacity,
+                  people: `${resource.people_capacity_lower}${resource.people_capacity_upper ? `-${resource.people_capacity_upper}` : ''}`,
                 })
                 : '-'
             }


### PR DESCRIPTION
People capacity is now split into two fields: `people_capacity_lower` and  `people_capacity_upper`. Display the range as "lower - upper" if people_capacity_upper has a value, otherwise display only the lower value.

<img width="600" alt="example" src="https://github.com/user-attachments/assets/354dbcbd-6dd9-4498-bb7c-b0adba072531" />


Refs TTVA-217