### PR TITLE
Refs TTVA-223 | Re-fetch user once email is updated

### DIFF
--- a/app/pages/AppContainer.js
+++ b/app/pages/AppContainer.js
@@ -106,6 +106,7 @@ export class UnconnectedAppContainer extends Component {
           <Footer />
           {(userId) && (
             <UserEmailFormModal
+              fetchUser={this.props.fetchUser}
               show={userId && !userHasEmail}
               userId={userId}
             />

--- a/app/shared/modals/user-email-form/UserEmailFormModal.js
+++ b/app/shared/modals/user-email-form/UserEmailFormModal.js
@@ -12,7 +12,9 @@ import { NOTIFICATION_TYPE } from '../../../../src/common/notification/constants
 import client from '../../../../src/common/api/client';
 import injectT from '../../../i18n/injectT';
 
-function UserEmailFormModal({ userId, show, t }) {
+function UserEmailFormModal({
+  fetchUser, userId, show, t,
+}) {
   const [open, setOpen] = useState(false);
   const [error, setError] = useState(false);
   const [emailMismatch, setEmailMismatch] = useState(false);
@@ -35,6 +37,7 @@ function UserEmailFormModal({ userId, show, t }) {
         .then(() => {
           createNotification(NOTIFICATION_TYPE.SUCCESS, t('UserEmailForm.emailSet'));
           setOpen(false);
+          fetchUser(userId);
         })
         .catch((e) => {
           setError(true);
@@ -129,6 +132,7 @@ function UserEmailFormModal({ userId, show, t }) {
 }
 
 UserEmailFormModal.propTypes = {
+  fetchUser: PropTypes.func.isRequired,
   userId: PropTypes.string.isRequired,
   show: PropTypes.bool.isRequired,
   t: PropTypes.func.isRequired,


### PR DESCRIPTION
Re-fetch user once email is updated. Email was missing e.g. in reservation confirmation page as the updated email was not yet updated to the user object.

Refs TTVA-223